### PR TITLE
Fixed Binary Stars Generating Inside themselves

### DIFF
--- a/Scripts/Generators/GS2Dev/Stars.cs
+++ b/Scripts/Generators/GS2Dev/Stars.cs
@@ -29,7 +29,7 @@ namespace GalacticScale.Generators
 
             binary.radius = Clamp(star.radius * .6f, 0.01f, binaryRadius);
             binary.Decorative = true;
-            var offset = (star.RadiusLY + binary.RadiusLY) * preferences.GetFloat("binaryDistanceMulti", 1f) * random.NextFloat(1.1f, 1.3f);
+            var offset = (star.RadiusLY * 2 + binary.RadiusLY * 2) * preferences.GetFloat("binaryDistanceMulti", 1f) * random.NextFloat(1.1f, 1.3f);
             star.genData.Add("binaryOffset", offset);
             binary.position = new VectorLF3(offset, 0, 0);
             star.luminosity += binary.luminosity;


### PR DESCRIPTION
The issue seems to be with the calculation of the binary star's offset position. The offset is currently calculated using the sum of the radii of the two stars.

However, the offset should be calculated based on the distance between the centers of the two stars, not the sum of their radii.

This change ensures that the offset accounts for the combined size of both stars. By multiplying the radius by 2 of each star in the offset calculation, it shifts the position of the binary star away from the primary star, preventing them from generating inside each other.

By multiplying the radius of each star by 2 in the calculation, you are effectively using the diameter of each star instead of just the radius. This ensures that the offset takes into account the size of both stars when calculating the distance between their centers.