### PR TITLE
Fix stuck on loading due to ThreadFlag

### DIFF
--- a/Scripts/Patches/GameLoader/FixedUpdate.cs
+++ b/Scripts/Patches/GameLoader/FixedUpdate.cs
@@ -18,6 +18,8 @@ namespace GalacticScale
         [HarmonyPatch(typeof(GameLoader), "FixedUpdate")]
         public static bool FixedUpdate(ref GameLoader __instance)
         {
+            if (VFInput.escape) OnEsc(__instance);
+
             // GS2.Warn($"Start {__instance.frame}");
             if (GS2.IsMenuDemo || GS2.Vanilla) return true;
             // GS2.DevLog("Not Vanilla");
@@ -159,6 +161,12 @@ namespace GalacticScale
             // GS2.DevLog("Increasing Frame");
             __instance.frame++;
             return false;
+        }
+
+        private static void OnEsc(GameLoader gameLoader)
+        {
+            GS2.Warn("User hit esc to abort loading");
+            gameLoader.LoadFailedMBCallback();
         }
     }
 }

--- a/Scripts/Patches/PlanetModelingManager/EndPlanetCalculateThread.cs
+++ b/Scripts/Patches/PlanetModelingManager/EndPlanetCalculateThread.cs
@@ -1,0 +1,23 @@
+﻿using HarmonyLib;
+using static PlanetModelingManager;
+
+namespace GalacticScale
+{
+    public partial class PatchOnPlanetModelingManager
+    {
+        [HarmonyPrefix, HarmonyPatch(typeof(PlanetModelingManager), "EndPlanetCalculateThread")]
+        public static bool EndPlanetCalculateThread()
+        {
+            lock (planetCalculateThreadFlagLock)
+            {
+                // Change: If the ThreadFlag is already ended, don't change it to ending
+                if (planetCalculateThreadFlag == ThreadFlag.Running)
+                {
+                    planetCalculateThreadFlag = ThreadFlag.Ending;
+                    GS2.Log("ThreadFlag: Running => Ending");
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/Scripts/Patches/PlanetModelingManager/EndPlanetComputeThread.cs
+++ b/Scripts/Patches/PlanetModelingManager/EndPlanetComputeThread.cs
@@ -1,0 +1,23 @@
+﻿using HarmonyLib;
+using static PlanetModelingManager;
+
+namespace GalacticScale
+{
+    public partial class PatchOnPlanetModelingManager
+    {
+        [HarmonyPrefix, HarmonyPatch(typeof(PlanetModelingManager), "EndPlanetComputeThread")]
+        public static bool EndPlanetComputeThread()
+        {
+            lock (planetComputeThreadFlagLock)
+            {
+                // Change: If the ThreadFlag is already ended, don't change it to ending
+                if (planetComputeThreadFlag == ThreadFlag.Running)
+                {
+                    planetComputeThreadFlag = ThreadFlag.Ending;
+                    GS2.Log("ThreadFlag: Running => Ending");
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/Scripts/Patches/PlanetModelingManager/PlanetCalculateMainThread.cs
+++ b/Scripts/Patches/PlanetModelingManager/PlanetCalculateMainThread.cs
@@ -1,5 +1,4 @@
-﻿using System.Threading;
-using HarmonyLib;
+﻿using HarmonyLib;
 using static PlanetModelingManager;
 
 namespace GalacticScale
@@ -8,9 +7,10 @@ namespace GalacticScale
     {
         [HarmonyPrefix]
         [HarmonyPatch(typeof(PlanetModelingManager), "PlanetCalculateThreadMain")]
-        public static bool PlanetCalculateThreadMain(ref ThreadFlag ___planetCalculateThreadFlag, ref ThreadFlagLock ___planetCalculateThreadFlagLock, ref Thread ___planetCalculateThread)
+        public static bool PlanetCalculateThreadMain()
         {
             Modeler.Calculate();
+            GS2.Log("Loop end. ThreadFlag: " + planetCalculateThreadFlag);
             return false;
         }
     }

--- a/Scripts/Patches/PlanetModelingManager/PlanetComputeMainThread.cs
+++ b/Scripts/Patches/PlanetModelingManager/PlanetComputeMainThread.cs
@@ -1,5 +1,4 @@
-﻿using System.Threading;
-using HarmonyLib;
+﻿using HarmonyLib;
 using static PlanetModelingManager;
 
 namespace GalacticScale
@@ -8,9 +7,10 @@ namespace GalacticScale
     {
         [HarmonyPrefix]
         [HarmonyPatch(typeof(PlanetModelingManager), "PlanetComputeThreadMain")]
-        public static bool PlanetComputeThreadMain(ref ThreadFlag ___planetComputeThreadFlag, ref ThreadFlagLock ___planetComputeThreadFlagLock, ref Thread ___planetComputeThread)
+        public static bool PlanetComputeThreadMain()
         {
-            Modeler.Compute(ref ___planetComputeThreadFlag, ref ___planetComputeThreadFlagLock, ref ___planetComputeThread);
+            Modeler.Compute();
+            GS2.Log("Loop end. ThreadFlag: " + planetComputeThreadFlag);
             return false;
         }
     }

--- a/Scripts/Patches/PlanetModelingManager/Start.cs
+++ b/Scripts/Patches/PlanetModelingManager/Start.cs
@@ -12,6 +12,7 @@ namespace GalacticScale
             PlanetModelingManager.modPlanetReqList = new Queue<PlanetData>(100);
             PlanetModelingManager.fctPlanetReqList = new Queue<PlanetData>(100);
             PlanetModelingManager.calPlanetReqList = new Queue<PlanetData>(100);
+            GS2.Log($"ThreadFlag: {PlanetModelingManager.planetComputeThreadFlag},{PlanetModelingManager.planetCalculateThreadFlag} => Running");
             return true;
         }
     }

--- a/Scripts/Patches/UIGameLoadingSplash/Update.cs
+++ b/Scripts/Patches/UIGameLoadingSplash/Update.cs
@@ -10,7 +10,7 @@ namespace GalacticScale
         [HarmonyPatch(typeof(UIGameLoadingSplash), "Update")]
         public static void Update(ref Text ___promptText)
         {
-            var status = "If the game fails to load it will timeout in 20s. Read the FAQ @ https://centrebra.in/\r\n".Translate();
+            var status = "If the game fails to load it will timeout in 20s. ESC to abort loading. Read the FAQ @ https://centrebra.in/\r\n".Translate();
 
             if (!GS2.Vanilla && GameMain.localStar != null && !GameMain.localStar.loaded && GameMain.localStar.planets != null && GameMain.localStar.planets.Length > 0) GetStatusText(ref status, GameMain.localStar);
             // else

--- a/Scripts/Planet Generation/Modeler.Calculate.cs
+++ b/Scripts/Planet Generation/Modeler.Calculate.cs
@@ -21,90 +21,95 @@ namespace GalacticScale
             for (;;)
             {
                 calcPlanet = null;
-                var num = 0;
-                obj2 = planetCalculateThreadFlagLock;
-                lock (obj2)
+                lock (planetProcessingLock)
                 {
-                    if (planetCalculateThreadFlag != ThreadFlag.Running)
+                    obj2 = planetCalculateThreadFlagLock;
+                    lock (obj2)
                     {
-                        planetCalculateThreadFlag = ThreadFlag.Ended;
+                        if (planetCalculateThreadFlag != ThreadFlag.Running)
+                        {
+                            planetCalculateThreadFlag = ThreadFlag.Ended;
+                            break;
+                        }
 
-                        break;
+                        if (obj != planetCalculateThread)
+                        {
+                            GS2.Warn("End due to planetCalculateThread mismatch");
+                            break;
+                        }
                     }
 
-                    if (obj != planetCalculateThread) break;
-                }
 
-                
-                var obj3 = calPlanetReqList;
-                lock (obj3)
-                {
-                    if (calPlanetReqList.Count > 0) calcPlanet = calPlanetReqList.Dequeue();
-                }
-
-                if (calcPlanet != null)
-                {
-                    processing.Add(calcPlanet);
-                    try
+                    var obj3 = calPlanetReqList;
+                    lock (obj3)
                     {
-                        var planetAlgorithm = Algorithm(calcPlanet);
-                        if (planetAlgorithm != null)
+                        if (calPlanetReqList.Count > 0) calcPlanet = calPlanetReqList.Dequeue();
+                    }
+
+                    if (calcPlanet != null)
+                    {
+                        processing.Add(calcPlanet);
+                        try
                         {
-                            var highStopwatch = new HighStopwatch();
-                            highStopwatch.Begin();
-                            calcPlanet.data = new PlanetRawData(calcPlanet.precision);
-                            if (calcPlanet == null || calcPlanet.data == null) return;                            calcPlanet.modData = calcPlanet.data.InitModData(calcPlanet.modData);
-                            if (calcPlanet == null || calcPlanet.data == null) return;                            calcPlanet.data.CalcVerts();
-                            if (calcPlanet == null || calcPlanet.data == null) return;                            calcPlanet.aux = new PlanetAuxData(calcPlanet);
-                            if (calcPlanet == null || calcPlanet.data == null || planetAlgorithm == null) return;                            planetAlgorithm.GenerateTerrain(calcPlanet.mod_x, calcPlanet.mod_y);
-                            if (calcPlanet == null || calcPlanet.data == null || planetAlgorithm == null)
+                            var planetAlgorithm = Algorithm(calcPlanet);
+                            if (planetAlgorithm != null)
                             {
-                                GS2.Log("Aborted");
-                            } else planetAlgorithm.CalcWaterPercent();
-                            if (calcPlanet == null || calcPlanet.data == null) return;                            var duration = highStopwatch.duration;
-                            highStopwatch.Begin();
-                            if (calcPlanet == null || calcPlanet.data == null || planetAlgorithm == null) return;                            if (calcPlanet.type != EPlanetType.Gas) planetAlgorithm.GenerateVegetables();
-                            if (calcPlanet == null || calcPlanet.data == null) return;                            var duration2 = highStopwatch.duration;
-                            highStopwatch.Begin();
-                            if (calcPlanet == null || calcPlanet.data == null || planetAlgorithm == null) return;                            if (calcPlanet.type != EPlanetType.Gas) planetAlgorithm.GenerateVeins();
-                            if (calcPlanet == null || calcPlanet.data == null) return;                            calcPlanet.CalculateVeinGroups();
-                            if (calcPlanet == null || calcPlanet.data == null) return;                            calcPlanet.GenBirthPoints();
-                            if (calcPlanet == null || calcPlanet.data == null) return;
-                            var duration3 = highStopwatch.duration;
-                            if (planetCalculateThreadLogs != null)
-                            {
-                                var obj4 = planetCalculateThreadLogs;
-                                lock (obj4)
+                                var highStopwatch = new HighStopwatch();
+                                highStopwatch.Begin();
+                                calcPlanet.data = new PlanetRawData(calcPlanet.precision);
+                                if (calcPlanet == null || calcPlanet.data == null) return; calcPlanet.modData = calcPlanet.data.InitModData(calcPlanet.modData);
+                                if (calcPlanet == null || calcPlanet.data == null) return; calcPlanet.data.CalcVerts();
+                                if (calcPlanet == null || calcPlanet.data == null) return; calcPlanet.aux = new PlanetAuxData(calcPlanet);
+                                if (calcPlanet == null || calcPlanet.data == null || planetAlgorithm == null) return; planetAlgorithm.GenerateTerrain(calcPlanet.mod_x, calcPlanet.mod_y);
+                                if (calcPlanet == null || calcPlanet.data == null || planetAlgorithm == null)
                                 {
-                                    planetCalculateThreadLogs.Add(string.Format("{0}\r\nGenerate Terrain {1:F5} s\r\nGenerate Vegetables {2:F5} s\r\nGenerate Veins {3:F5} s\r\n", calcPlanet.displayName, duration, duration2, duration3));
+                                    GS2.Log("Aborted");
                                 }
+                                else planetAlgorithm.CalcWaterPercent();
+                                if (calcPlanet == null || calcPlanet.data == null) return; var duration = highStopwatch.duration;
+                                highStopwatch.Begin();
+                                if (calcPlanet == null || calcPlanet.data == null || planetAlgorithm == null) return; if (calcPlanet.type != EPlanetType.Gas) planetAlgorithm.GenerateVegetables();
+                                if (calcPlanet == null || calcPlanet.data == null) return; var duration2 = highStopwatch.duration;
+                                highStopwatch.Begin();
+                                if (calcPlanet == null || calcPlanet.data == null || planetAlgorithm == null) return; if (calcPlanet.type != EPlanetType.Gas) planetAlgorithm.GenerateVeins();
+                                if (calcPlanet == null || calcPlanet.data == null) return; calcPlanet.CalculateVeinGroups();
+                                if (calcPlanet == null || calcPlanet.data == null) return; calcPlanet.GenBirthPoints();
+                                if (calcPlanet == null || calcPlanet.data == null) return;
+                                var duration3 = highStopwatch.duration;
+                                if (planetCalculateThreadLogs != null)
+                                {
+                                    var obj4 = planetCalculateThreadLogs;
+                                    lock (obj4)
+                                    {
+                                        planetCalculateThreadLogs.Add(string.Format("{0}\r\nGenerate Terrain {1:F5} s\r\nGenerate Vegetables {2:F5} s\r\nGenerate Veins {3:F5} s\r\n", calcPlanet.displayName, duration, duration2, duration3));
+                                    }
+                                }
+
+                                calcPlanet.NotifyCalculated();
+                                processing.Remove(calcPlanet);
                             }
-                            
-                            calcPlanet.NotifyCalculated();
-                            processing.Remove(calcPlanet);
                         }
-                    }
-                    catch (Exception ex)
-                    {
-                        var obj5 = planetCalculateThreadError;
-                        lock (obj5)
+                        catch (Exception ex)
                         {
-                            if (string.IsNullOrEmpty(planetCalculateThreadError)) planetCalculateThreadError = ex.ToString();
+                            var obj5 = planetCalculateThreadError;
+                            lock (obj5)
+                            {
+                                if (string.IsNullOrEmpty(planetCalculateThreadError)) planetCalculateThreadError = ex.ToString();
+                            }
+
+                            calcPlanet.calculated = false;
+                            processing.Remove(calcPlanet);
+
                         }
 
-                        calcPlanet.calculated = false;
-                        processing.Remove(calcPlanet);
-
+                        calcPlanet.calculating = false;
+                        if (processing.Contains(calcPlanet)) processing.Remove(calcPlanet);
                     }
-
-                    calcPlanet.calculating = false;
-                    if (processing.Contains( calcPlanet)) processing.Remove(calcPlanet);
-
                 }
 
                 if (calcPlanet == null)
                     Thread.Sleep(50);
-                else if (num % 20 == 0) Thread.Sleep(2);
+                else Thread.Sleep(2);
             }
         }
     }

--- a/Scripts/Planet Generation/Modeler.Compute.cs
+++ b/Scripts/Planet Generation/Modeler.Compute.cs
@@ -12,7 +12,7 @@ namespace GalacticScale
     {
         static PlanetData compPlanet = null;
         
-        public static bool Compute(ref ThreadFlag ___planetComputeThreadFlag, ref ThreadFlagLock ___planetComputeThreadFlagLock, ref Thread ___planetComputeThread)
+        public static bool Compute()
         {
             Log("Compute");
             object obj = null;
@@ -28,126 +28,132 @@ namespace GalacticScale
                 compPlanet = null;
                 var pqsw = new HighStopwatch();
                 pqsw.Begin();
-                var num = 0;
-                lock (planetComputeThreadFlagLock)
+                lock (planetProcessingLock)
                 {
-                    if (planetComputeThreadFlag != ThreadFlag.Running)
+                    lock (planetComputeThreadFlagLock)
                     {
-                        planetComputeThreadFlag = ThreadFlag.Ended;
-                        planetQueue.Clear();
-                        planetModQueue.Clear();
-                        planetQueueSorted = false;
-                        planetModQueueSorted = false;
-                        Warn($"Ended after:{pqsw.duration:F5}");
-                        return false;
+                        if (planetComputeThreadFlag != ThreadFlag.Running)
+                        {
+                            planetComputeThreadFlag = ThreadFlag.Ended;
+                            planetQueue.Clear();
+                            planetModQueue.Clear();
+                            planetQueueSorted = false;
+                            planetModQueueSorted = false;
+                            Warn($"Ended after:{pqsw.duration:F5}");
+                            return false;
+                        }
+
+                        if (obj != planetComputeThread)
+                        {
+                            Warn("End due to planetComputeThread mismatch");
+                            return false;
+                        }
                     }
 
-                    if (obj != planetComputeThread) return false;
-                }
-
-                lock (genPlanetReqList)
-                {
-                    if (genPlanetReqList.Count > 0)
+                    lock (genPlanetReqList)
                     {
-                        Log("Processing List");
-                        planetQueueSorted = false;
-                        while (genPlanetReqList.Count > 0) planetQueue.Add(genPlanetReqList.Dequeue());
-                    }
-                }
-
-                if (!planetQueueSorted && planetQueue.Count > 1)
-                    lock (planetQueue)
-                    {
-                        Log($"Sorting Queue with {planetQueue.Count} entries where Player:{GameMain.mainPlayer?.uPosition} localPlanet:{GameMain.localPlanet?.name}:{GameMain.localPlanet?.uPosition}");
-                        planetQueue.Sort(DistanceComparison);
-                        planetQueueSorted = true;
-                        Log("Sorted");
+                        if (genPlanetReqList.Count > 0)
+                        {
+                            Log("Processing List");
+                            planetQueueSorted = false;
+                            while (genPlanetReqList.Count > 0) planetQueue.Add(genPlanetReqList.Dequeue());
+                        }
                     }
 
-                if (planetQueue.Count > 0)
-                {
-                    
-                        
+                    if (!planetQueueSorted && planetQueue.Count > 1)
+                        lock (planetQueue)
+                        {
+                            Log($"Sorting Queue with {planetQueue.Count} entries where Player:{GameMain.mainPlayer?.uPosition} localPlanet:{GameMain.localPlanet?.name}:{GameMain.localPlanet?.uPosition}");
+                            planetQueue.Sort(DistanceComparison);
+                            planetQueueSorted = true;
+                            Log("Sorted");
+                        }
+
+                    if (planetQueue.Count > 0)
+                    {
+
+
                         compPlanet = planetQueue[0];
-                        if (!processing.Contains( compPlanet)) processing.Add(compPlanet);
+                        if (!processing.Contains(compPlanet)) processing.Add(compPlanet);
                         ModellingDone = false;
                         planetQueue.RemoveAt(0);
                         Log($"Retrieved sorted planet from list: {compPlanet.name}");
-                    
-                }
 
-                if (compPlanet != null && planetComputeThreadFlag == ThreadFlag.Running)
-                {
-                    Log($"Preamble time taken:{pqsw.duration:F5}");
-                    try
+                    }
+
+                    if (compPlanet != null && planetComputeThreadFlag == ThreadFlag.Running)
                     {
-                        var planetAlgorithm = Algorithm(compPlanet);
-                        if (planetAlgorithm != null)
+                        Log($"Preamble time taken:{pqsw.duration:F5}");
+                        try
                         {
-                            var highStopwatch = new HighStopwatch();
-                            var num2 = 0.0;
-                            var num3 = 0.0;
-                            var num4 = 0.0;
-                            if (compPlanet.data == null)
+                            var planetAlgorithm = Algorithm(compPlanet);
+                            if (planetAlgorithm != null)
                             {
-                                Log($"Creating Planet {compPlanet.name}");
-                                highStopwatch.Begin();
-                                compPlanet.data = new PlanetRawData(compPlanet.precision);
-                                if (compPlanet == null) return false;
-                                compPlanet.modData = compPlanet.data.InitModData(compPlanet.modData);
-                                if (compPlanet == null) return false;
-                                compPlanet.data.CalcVerts();
-                                if (compPlanet == null) return false;
-                                compPlanet.aux = new PlanetAuxData(compPlanet);
-                                Log("Generating Terrain");
-                                if (compPlanet == null) return false;
-                                planetAlgorithm.GenerateTerrain(compPlanet.mod_x, compPlanet.mod_y);
-                                if (compPlanet == null) return false;
-                                if (!UIRoot.instance.backToMainMenu) planetAlgorithm.CalcWaterPercent();
-                                num2 = highStopwatch.duration;
-                            }
-
-                            if (compPlanet.factory == null && !UIRoot.instance.backToMainMenu)
-                            {
-                                Log("Creating Factory");
-                                highStopwatch.Begin();
-                                if (compPlanet.type != EPlanetType.Gas && compPlanet.data != null) planetAlgorithm.GenerateVegetables();
-                                num3 = highStopwatch.duration;
-                                highStopwatch.Begin();
-                                if (compPlanet.type != EPlanetType.Gas && compPlanet.data != null) planetAlgorithm.GenerateVeins();
-                                if (compPlanet.data != null) compPlanet.CalculateVeinGroups();
-                                num4 = highStopwatch.duration;
-                            }
-
-                            // else if (planetData.galaxy.birthPlanetId == planetData.id) //Added after 0.9.25 update
-                            // {
-                            //     planetData.GenBirthPoints();
-                            // }//end add 0.9.25 update
-                            if (planetComputeThreadLogs != null)
-                                lock (planetComputeThreadLogs)
+                                var highStopwatch = new HighStopwatch();
+                                var num2 = 0.0;
+                                var num3 = 0.0;
+                                var num4 = 0.0;
+                                if (compPlanet.data == null)
                                 {
-                                    planetComputeThreadLogs.Add($"{compPlanet.displayName}\r\nGenerate Terrain {num2:F5} s\r\nGenerate Vegetables {num3:F5} s\r\nGenerate Veins {num4:F5} s\r\n");
-                                    Log($"{compPlanet.displayName}\r\nGenerate Terrain {num2:F5} s\r\nGenerate Vegetables {num3:F5} s\r\nGenerate Veins {num4:F5} s\r\n");
+                                    Log($"Creating Planet {compPlanet.name}");
+                                    highStopwatch.Begin();
+                                    compPlanet.data = new PlanetRawData(compPlanet.precision);
+                                    if (compPlanet == null) return false;
+                                    compPlanet.modData = compPlanet.data.InitModData(compPlanet.modData);
+                                    if (compPlanet == null) return false;
+                                    compPlanet.data.CalcVerts();
+                                    if (compPlanet == null) return false;
+                                    compPlanet.aux = new PlanetAuxData(compPlanet);
+                                    Log("Generating Terrain");
+                                    if (compPlanet == null) return false;
+                                    planetAlgorithm.GenerateTerrain(compPlanet.mod_x, compPlanet.mod_y);
+                                    if (compPlanet == null) return false;
+                                    if (!UIRoot.instance.backToMainMenu) planetAlgorithm.CalcWaterPercent();
+                                    num2 = highStopwatch.duration;
                                 }
 
-                            compPlanet?.NotifyCalculated();
-                            if (processing.Contains( compPlanet)) processing.Remove(compPlanet);
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        lock (planetComputeThreadError)
-                        {
-                            if (processing.Contains( compPlanet)) processing.Remove(compPlanet);
-                            if (string.IsNullOrEmpty(planetComputeThreadError))
-                                planetComputeThreadError = ex.ToString();
-                        }
-                    }
+                                if (compPlanet.factory == null && !UIRoot.instance.backToMainMenu)
+                                {
+                                    Log("Creating Factory");
+                                    highStopwatch.Begin();
+                                    if (compPlanet.type != EPlanetType.Gas && compPlanet.data != null) planetAlgorithm.GenerateVegetables();
+                                    num3 = highStopwatch.duration;
+                                    highStopwatch.Begin();
+                                    if (compPlanet.type != EPlanetType.Gas && compPlanet.data != null) planetAlgorithm.GenerateVeins();
+                                    if (compPlanet.data != null) compPlanet.CalculateVeinGroups();
+                                    num4 = highStopwatch.duration;
+                                }
 
-                    lock (modPlanetReqList)
-                    {
-                        //Log($"Queuing {planetData.name} in modPlanetReqList after {pqsw.duration:F5}");
-                        modPlanetReqList.Enqueue(compPlanet);
+                                // else if (planetData.galaxy.birthPlanetId == planetData.id) //Added after 0.9.25 update
+                                // {
+                                //     planetData.GenBirthPoints();
+                                // }//end add 0.9.25 update
+                                if (planetComputeThreadLogs != null)
+                                    lock (planetComputeThreadLogs)
+                                    {
+                                        planetComputeThreadLogs.Add($"{compPlanet.displayName}\r\nGenerate Terrain {num2:F5} s\r\nGenerate Vegetables {num3:F5} s\r\nGenerate Veins {num4:F5} s\r\n");
+                                        Log($"{compPlanet.displayName}\r\nGenerate Terrain {num2:F5} s\r\nGenerate Vegetables {num3:F5} s\r\nGenerate Veins {num4:F5} s\r\n");
+                                    }
+
+                                compPlanet?.NotifyCalculated();
+                                if (processing.Contains(compPlanet)) processing.Remove(compPlanet);
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            lock (planetComputeThreadError)
+                            {
+                                if (processing.Contains(compPlanet)) processing.Remove(compPlanet);
+                                if (string.IsNullOrEmpty(planetComputeThreadError))
+                                    planetComputeThreadError = ex.ToString();
+                            }
+                        }
+
+                        lock (modPlanetReqList)
+                        {
+                            //Log($"Queuing {planetData.name} in modPlanetReqList after {pqsw.duration:F5}");
+                            modPlanetReqList.Enqueue(compPlanet);
+                        }
                     }
                 }
 
@@ -156,7 +162,7 @@ namespace GalacticScale
                     ModellingDone = true;
                     Thread.Sleep(50);
                 }
-                else if (num % 20 == 0)
+                else
                 {
                     Thread.Sleep(2);
                 }


### PR DESCRIPTION
- Fix that game loading sometimes stuck because the `planetComputeThreadFlag` get set from `Ended` to `Ending` in vanilla EndPlanetComputeThread.
- Add the ability to abort loading in game loading screen by ESC.
- Add `planetProcessingLock` to lock the main processing part as in vanilla changes in 0.10.32.25682. 
![image](https://github.com/user-attachments/assets/2d978f81-e1c9-4538-ad67-cd0f11223cdb)
