### PR TITLE
Scale the craft star-frame enter/eject thresholds to the star's real envelope

### DIFF
--- a/Bootstrap.cs
+++ b/Bootstrap.cs
@@ -71,6 +71,7 @@ namespace GalacticScale
                 harmony.PatchAll(typeof(PlanetSizeTranspiler));
                 harmony.PatchAll(typeof(TurretComponentTranspiler));
                 harmony.PatchAll(typeof(UnitComponentTranspiler));
+                harmony.PatchAll(typeof(DetermineCraftAstroIdTranspiler));
                 harmony.PatchAll(typeof(LagFixTranspiler));
                 // Environment.SetEnvironmentVariable("MONOMOD_DMD_DUMP", "");
                 harmony.PatchAll(typeof(PatchOnUnspecified_Debug));

--- a/Scripts/Patches/Transpilers/PlanetSizeTranspiler/DetermineCraftAstroIdTranspiler.cs
+++ b/Scripts/Patches/Transpilers/PlanetSizeTranspiler/DetermineCraftAstroIdTranspiler.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using HarmonyLib;
+using static System.Reflection.Emit.OpCodes;
+
+namespace GalacticScale
+{
+    public class DetermineCraftAstroIdTranspiler
+    {
+        // #258 / #247: craft only join a star's astro frame within a hardcoded
+        // 40.5 AU (and leave past 45 AU). SensorLogic_Space gates all fleet
+        // auto-targeting on sharing the star frame, so on GS2 systems whose
+        // hives orbit beyond 40.5 AU, fleets can never self-acquire - they see
+        // nothing while the Dark Fog freely discovers them. Scale both
+        // thresholds to the star's real envelope (Utils.CraftAstroEnvelope,
+        // floored at vanilla, enter/eject ratio preserved).
+        //
+        // UnitComponent.DetermineCraftAstroId and FleetComponent.DetermineCraftAstroId
+        // are byte-identical (0.10.34.28529); one transpiler serves both.
+        //
+        // ENTER site: `dist < 1619999.957...` where dist (loc.1) was written by
+        // SpaceSector.GetNearestStar and loc.0 holds that StarData - replace
+        // the constant with `ldloc.0; call GetCraftAstroEnterMeters`.
+        // EJECT site: `craft.pos.sqrMagnitude <= 3240000000000.0` runs in the
+        // star-local frame; loc.0 is NOT initialized on this path, so the star
+        // is recovered from craft.astroId / 100 via GalaxyData.StarById -
+        // replace the constant with that lookup + GetCraftAstroEjectMetersSqr.
+        [HarmonyTranspiler]
+        [HarmonyPatch(typeof(UnitComponent), nameof(UnitComponent.DetermineCraftAstroId))]
+        [HarmonyPatch(typeof(FleetComponent), nameof(FleetComponent.DetermineCraftAstroId))]
+        public static IEnumerable<CodeInstruction> FixCraftFrameGate(IEnumerable<CodeInstruction> instructions, System.Reflection.MethodBase __originalMethod)
+        {
+            var enterHelper = AccessTools.Method(typeof(Utils), nameof(Utils.GetCraftAstroEnterMeters));
+            var ejectHelper = AccessTools.Method(typeof(Utils), nameof(Utils.GetCraftAstroEjectMetersSqr));
+            var starById = AccessTools.Method(typeof(GalaxyData), nameof(GalaxyData.StarById));
+            var galaxyField = AccessTools.Field(typeof(SpaceSector), nameof(SpaceSector.galaxy));
+            var astroIdField = AccessTools.Field(typeof(CraftData), nameof(CraftData.astroId));
+
+            var matcher = new CodeMatcher(instructions)
+                .MatchForward(false,
+                    new CodeMatch(i => i.opcode == Ldc_R8 && i.operand is double d && d == 1619999.9570846558));
+            if (matcher.IsInvalid)
+            {
+                GS2.Error($"DetermineCraftAstroId transpiler: 40.5 AU enter constant not found in {__originalMethod?.DeclaringType?.Name} (game update changed it?). Craft star-frame gate stays vanilla.");
+                return instructions;
+            }
+            // replace the enter constant: loc.0 already holds the nearest StarData
+            matcher.SetInstruction(new CodeInstruction(Ldloc_0));
+            matcher.Advance(1).InsertAndAdvance(new CodeInstruction(Call, enterHelper));
+
+            matcher.Start().MatchForward(false,
+                new CodeMatch(i => i.opcode == Ldc_R8 && i.operand is double d && d == 3240000000000.0));
+            if (matcher.IsInvalid)
+            {
+                GS2.Error($"DetermineCraftAstroId transpiler: 45 AU eject constant not found in {__originalMethod?.DeclaringType?.Name} (game update changed it?). Craft star-frame gate stays vanilla.");
+                return instructions;
+            }
+            // replace the eject constant: star = sector.galaxy.StarById(craft.astroId / 100)
+            matcher.SetInstruction(new CodeInstruction(Ldarg_1));
+            matcher.Advance(1)
+                .InsertAndAdvance(new CodeInstruction(Ldfld, galaxyField))
+                .InsertAndAdvance(new CodeInstruction(Ldarg_2))
+                .InsertAndAdvance(new CodeInstruction(Ldfld, astroIdField))
+                .InsertAndAdvance(new CodeInstruction(Ldc_I4_S, (sbyte)100))
+                .InsertAndAdvance(new CodeInstruction(Div))
+                .InsertAndAdvance(new CodeInstruction(Callvirt, starById))
+                .InsertAndAdvance(new CodeInstruction(Call, ejectHelper));
+
+            return matcher.InstructionEnumeration();
+        }
+    }
+}

--- a/Scripts/Utils/CraftAstroEnvelope.cs
+++ b/Scripts/Utils/CraftAstroEnvelope.cs
@@ -1,0 +1,82 @@
+using System;
+
+namespace GalacticScale
+{
+    public static partial class Utils
+    {
+        // Craft star-frame envelope for DetermineCraftAstroId (#258 / #247).
+        //
+        // Vanilla hardcodes the star-frame ENTER threshold at 40.5 AU
+        // (ldc.r8 1619999.9570846558 meters) and the EJECT threshold at 45 AU
+        // (ldc.r8 3240000000000.0 = (1.8e6 m)^2, compared against sqrMagnitude).
+        // GS2 stars can have system radii and Dark Fog hive orbits far beyond
+        // 40.5 AU, so craft near those hives never enter the star's astro frame
+        // (astroId stays 0) and SensorLogic_Space's star-astroId gate rejects
+        // every enemy: fleets can never auto-acquire (live-confirmed on the
+        // issue-258 save: 0 gate passes in 7837 shadow evaluations).
+        //
+        // Envelope = max(systemRadius, hive orbit max, LIVE hive astro distance)
+        // * 1.05, floored at the vanilla 40.5 AU so small systems never get a
+        // TIGHTER gate than vanilla. The live-distance term matters because
+        // GS2's SpaceSector.Import prefix clamps oversized hiveAstroOrbit radii
+        // down to systemRadius, but does not move the already-placed hive astro
+        // - the actual position is the truth the envelope must cover.
+        // Enter and eject scale together, preserving the vanilla 45/40.5 ratio
+        // so the hysteresis band behaves identically at any scale.
+
+        const double VanillaEnterAu = 40.5;
+        const double VanillaCraftEnterMeters = 1619999.9570846558; // the IL literal
+        const double VanillaCraftEjectMetersSqr = 3240000000000.0; // (45 AU in m)^2
+        const double CraftEjectOverEnter = 45.0 / 40.5;
+        const double CraftEnvelopePad = 1.05;
+        const double AuMeters = 40000.0;
+
+        static double CraftAstroEnvelopeAu(StarData star)
+        {
+            if (star == null) return VanillaEnterAu;
+            double maxHive = 0.0;
+            var orbits = star.hiveAstroOrbits;
+            if (orbits != null)
+                for (var i = 0; i < orbits.Length; i++)
+                    if (orbits[i] != null && orbits[i].orbitRadius > maxHive)
+                        maxHive = orbits[i].orbitRadius;
+            // live hive astro positions beat the (possibly import-clamped) orbit table.
+            // astros[] is indexed by hiveAstroId - 1000000 (not hiveAstroId).
+            // dfHives[star.index] is the list head; further hives are nextSibling.
+            var sector = GameMain.spaceSector;
+            var astros = sector?.astros;
+            var heads = sector?.dfHives;
+            if (astros != null && heads != null
+                && star.index >= 0 && star.index < heads.Length)
+            {
+                for (var hive = heads[star.index]; hive != null; hive = hive.nextSibling)
+                {
+                    if (hive.starData != star) continue;
+                    var hiveId = hive.hiveAstroId - 1000000;
+                    if (hiveId < 0 || hiveId >= astros.Length) continue;
+                    if (astros[hiveId].id <= 0) continue;
+                    var d = (astros[hiveId].uPos - star.uPosition).magnitude / AuMeters;
+                    if (d > maxHive) maxHive = d;
+                }
+            }
+            var env = Math.Max(star.systemRadius, maxHive) * CraftEnvelopePad;
+            return Math.Max(env, VanillaEnterAu);
+        }
+
+        public static double GetCraftAstroEnterMeters(StarData star)
+        {
+            try { return CraftAstroEnvelopeAu(star) * AuMeters; }
+            catch (Exception) { return VanillaCraftEnterMeters; }
+        }
+
+        public static double GetCraftAstroEjectMetersSqr(StarData star)
+        {
+            try
+            {
+                var eject = CraftAstroEnvelopeAu(star) * AuMeters * CraftEjectOverEnter;
+                return eject * eject;
+            }
+            catch (Exception) { return VanillaCraftEjectMetersSqr; }
+        }
+    }
+}


### PR DESCRIPTION
Fleets could never auto-acquire targets on large GS2 systems (#258): craft only join a star's astro frame within a hardcoded 40.5 AU (leaving past 45 AU), and SensorLogic_Space gates all fleet auto-targeting on sharing the star frame. On systems whose Dark Fog hives orbit beyond 40.5 AU, craft frames stay 0 forever — fleets see nothing while the Dark Fog freely discovers them (the reported one-sidedness).

Live confirmation on the issue-258 reporter's save: before this patch our instrumentation counted **0 star-gate passes in 7837 evaluations** (craft frame pinned at 0 vs star 3600); with the patch, fleets auto-engaged instantly in two different systems, with 1421 gate passes and the craft frame matching the star frame.

The fix scales both thresholds per star: envelope = max(systemRadius, largest hive orbit, largest live hive astro distance) × 1.05, floored at the vanilla 40.5 AU so small systems never get a tighter gate, with the vanilla 45/40.5 enter/eject ratio preserved. The live-distance term (astros indexed by hiveAstroId − 1000000, per-star sibling walk) matters because the SpaceSector.Import prefix clamps oversized hive orbitRadius values down to systemRadius without moving the already-placed hive astro — the actual position is what the envelope must cover.

UnitComponent.DetermineCraftAstroId and FleetComponent.DetermineCraftAstroId are byte-identical; one transpiler patches both (enter constant → nearest StarData already in loc.0 + helper; eject constant → StarById(craft.astroId/100) + squared helper). Zero-match guards per house convention. Known residual (documented, separate item): GetNearestStar picks the geometrically nearest star, so overlapping envelopes can neighbor-steal a craft at extreme range.

Fixes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)