### PR TITLE
Clear backToMainMenu when the galaxy-select screen opens

### DIFF
--- a/Scripts/Patches/UIGalaxySelect/_OnOpen.cs
+++ b/Scripts/Patches/UIGalaxySelect/_OnOpen.cs
@@ -19,6 +19,14 @@ namespace GalacticScale
         {
             //GS2.Warn("Fix");
 
+            // #233: quit-to-menu sets UIRoot.backToMainMenu and vanilla only clears it in
+            // CloseMainMenuUI (game-load start) - which this full-replacement prefix bypasses.
+            // GenerateVeins and the other planet-scan generators are gated on !backToMainMenu,
+            // so with the flag stuck every galaxy preview after the first quit scanned planets
+            // WITHOUT veins and the universe view showed no ore. Clear it the moment the
+            // galaxy-select screen opens: any quit teardown the flag guards is long finished.
+            if (UIRoot.instance != null) UIRoot.instance.backToMainMenu = false;
+
             if (GS2.canvasOverlay)
             {
                 //GS2.Warn("FIXING WITH GALAXYSELECT!");

--- a/Scripts/Planet Generation/Modeler.Scan.cs
+++ b/Scripts/Planet Generation/Modeler.Scan.cs
@@ -72,7 +72,10 @@ namespace GalacticScale
                         }
 
                         calcPlanet.scanning = false;
-                        calcPlanet.scanned = true;
+                        // #233 belt-and-suspenders: if the generators were skipped because a
+                        // quit was in progress (backToMainMenu gate), do NOT commit the planet
+                        // as scanned - an empty scan marked scanned locks "no ore" into the UI.
+                        calcPlanet.scanned = UIRoot.instance == null || !UIRoot.instance.backToMainMenu;
                         if (processing.Contains(calcPlanet)) processing.Remove(calcPlanet);
                     }
                 }


### PR DESCRIPTION
Fixes #233 (second new game shows planets with no ore).

Quit-to-menu sets `UIRoot.backToMainMenu`, and vanilla only clears it in `CloseMainMenuUI` — which runs on game-load start, and which GS2's `UIGalaxySelect._OnOpen` full replacement never reaches. GS2 gates `GenerateVeins` (and the other planet-scan generators) on `!backToMainMenu`, so after one quit every galaxy preview scanned planets *without* veins and still marked them scanned: the second new game's universe view showed no ore — only oceans/gas, which copy from themes rather than `GenerateVeins`. First game after boot was always clean because the flag starts false.

Fix: clear the flag when galaxy select opens (mirroring vanilla's intent — quit teardown is finished by then), and stop committing `scanned = true` when the generators were skipped, so an aborted scan can never lock an empty resource list into the UI.

Verified with a controlled pair on one machine: stock 2.78.5 reproduces the reporter's recipe exactly (new game → quit → new game → no ore); with this fix the same recipe shows fully populated veins, and the same seed regenerates the same galaxy structure (orbits, themes, radii identical).

Noted during verification, *not* addressed here: star names and vein amounts are not seed-stable in GS2 (same seed, same planet, different name and amounts across runs) — a pre-existing determinism issue that was unobservable while second generations were empty. Will be filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
