### PR TITLE
Make generation a pure function of the galaxy seed (fixes #290)

### DIFF
--- a/Scripts/Generators/GS2/GS2Generator.cs
+++ b/Scripts/Generators/GS2/GS2Generator.cs
@@ -198,7 +198,7 @@ namespace GalacticScale.Generators
                     // var tiPlanet = birthPlanet.Moons.Add(new GSPlanet("Titania McGrath", "Lol",
                     //     510, 0.13f, 66f, 900f, 0f,
                     //     66f, 360f, 0f, -1f));
-                    var tiPlanet = birthPlanet.Moons.Add(new GSPlanet("Titania McGrath", "AshenGelisol", GetStarMoonSize(birthStar, birthPlanet.Radius, false), 0.02f, 69f, 42069f, 0f, 69f, 420f, 0f, -1f));
+                    var tiPlanet = birthPlanet.Moons.Add(new GSPlanet("Titania McGrath", "AshenGelisol", GetStarMoonSize(birthStar, birthPlanet.Radius, false, new GS2.Random(GS2.Random.Mix(GSSettings.Seed, birthStar.Seed, 0x746974))), 0.02f, 69f, 42069f, 0f, 69f, 420f, 0f, -1f));
                     //tiPlanet.OrbitalPeriod = Utils.CalculateOrbitPeriodFromStarMass(tiPlanet.OrbitRadius, birthStar.mass);
                     return;
                 }

--- a/Scripts/Generators/GS2/Planets.cs
+++ b/Scripts/Generators/GS2/Planets.cs
@@ -123,7 +123,7 @@ namespace GalacticScale.Generators
 
             for (int i = 0; i < telluricCount - (isBirthStar && !startOnMoon ? 1 : 0); i++)
             {
-                int radius = GetStarPlanetSize(star);
+                int radius = GetStarPlanetSize(star, random);
                 GSPlanet p = new GSPlanet("planet_" + i, "Barren", radius, -1, -1, -1, -1, -1, -1, -1, -1, new GSPlanets());
                 p.genData.Add("hosttype", "star");
                 p.genData.Add("hostname", star.Name);
@@ -132,7 +132,7 @@ namespace GalacticScale.Generators
 
             for (int i = 0; i < gasCount; i++)
             {
-                int radius = Mathf.RoundToInt(GetStarGasSize(star) / 10f);
+                int radius = Mathf.RoundToInt(GetStarGasSize(star, random) / 10f);
                 GSPlanet p = new GSPlanet("planet_" + i, "Gas", radius, -1, -1, -1, -1, -1, -1, -1, -1, new GSPlanets());
                 if (!preferences.GetBool("hugeGasGiants", true)) p.Radius = 80;
                 p.Scale = 10f;
@@ -163,7 +163,7 @@ namespace GalacticScale.Generators
                 }
                 else
                 {
-                    int radius = GetStarPlanetSize(star);
+                    int radius = GetStarPlanetSize(star, random);
                     // GS2.Log("Picking No Host Planet");
                     randomPlanet = new GSPlanet("planet_" + i, "Barren", radius, -1, -1, -1, -1, -1, -1, -1, -1, new GSPlanets());
                     randomPlanet.genData.Add("hosttype", "star");
@@ -171,7 +171,7 @@ namespace GalacticScale.Generators
                     telPlanets.Add(randomPlanet);
                 }
 
-                GSPlanet moon = new GSPlanet("Moon " + i, "Barren", GetStarMoonSize(star, randomPlanet.Radius, hostGas), -1, -1, -1, -1, -1, -1, -1, -1, new GSPlanets());
+                GSPlanet moon = new GSPlanet("Moon " + i, "Barren", GetStarMoonSize(star, randomPlanet.Radius, hostGas, random), -1, -1, -1, -1, -1, -1, -1, -1, new GSPlanets());
                 randomPlanet.Moons.Add(moon);
                 moon.genData.Add("hosttype", "planet");
                 moon.genData.Add("hostname", randomPlanet.Name);
@@ -210,7 +210,7 @@ namespace GalacticScale.Generators
             {
                 // GS2.Log($"Picking Moon to host Secondary {gasPlanets.Count}/{telPlanets.Count}/{moonCount}/{secondaryMoonCount}");
                 GSPlanet randomMoon = random.Item(moons);
-                GSPlanet mm = new GSPlanet("MoonMoon" + i, "Barren", GetStarMoonSize(star, randomMoon.Radius, false), -1, -1,
+                GSPlanet mm = new GSPlanet("MoonMoon" + i, "Barren", GetStarMoonSize(star, randomMoon.Radius, false, random), -1, -1,
                     -1, -1, -1, -1, -1, -1);
                 mm.genData.Add("hosttype", "moon");
                 mm.genData.Add("hostname", randomMoon.Name);
@@ -255,51 +255,54 @@ namespace GalacticScale.Generators
 
         private void FudgeNumbersForPlanets(GSStar star)
         {
+            // #290: same fix as themes - star-scoped derived stream instead of the
+            // shared generator-instance rng
+            var rng = new GS2.Random(GS2.Random.Mix(GSSettings.Seed, star.Seed, 0x66756467));
             // GS2.Warn($"{star.displayType} {star.radius} {star.RadiusAU} {star.luminosity}");
             // GS2.Warn("Star RadiusAU, Star Luminance, HZMin, HZMax, HZ, Orbit Radius, LumInv, LumLin , intensity ");
             foreach (var body in star.Bodies)
             {
-                body.RotationPhase = random.Next(360);
+                body.RotationPhase = rng.Next(360);
                 if (GS2.IsPlanetOfStar(star, body))
                     // GS2.Warn($"SETTING Orbit Inclination of {body.Name} to random");
-                    body.OrbitInclination = random.NextFloat() * 4 + random.NextFloat() * 5;
+                    body.OrbitInclination = rng.NextFloat() * 4 + rng.NextFloat() * 5;
                 if (!GS2.IsPlanetOfStar(star, body))
                     // GS2.Warn($"SETTING Orbit Inclination of {body.Name} to random");
-                    body.OrbitInclination = random.NextFloat() * 50f;
-                body.OrbitPhase = random.Next(360);
-                body.Obliquity = random.NextFloat() * 20;
+                    body.OrbitInclination = rng.NextFloat() * 50f;
+                body.OrbitPhase = rng.Next(360);
+                body.Obliquity = rng.NextFloat() * 20;
                 var starInc = preferences.GetFloat($"{GetTypeLetterFromStar(star)}inclination");
                 var starLong = preferences.GetFloat($"{GetTypeLetterFromStar(star)}orbitLongitude", 0);
                 if (starLong == -1)
-                    body.OrbitLongitude = random.NextFloat() * 360f;
+                    body.OrbitLongitude = rng.NextFloat() * 360f;
                 else
-                    body.OrbitLongitude = random.NextFloat() * starLong;
+                    body.OrbitLongitude = rng.NextFloat() * starLong;
                 // GS2.Log($"StarInc {starInc}");
                 if (GS2.IsPlanetOfStar(star, body) && starInc > -1)
                 {
                     // GS2.Warn($"SETTING starInc Orbit Inclination of {star.Name} to {starInc}");
-                    if (starInc > 0) body.OrbitInclination = random.NextFloat(starInc);
+                    if (starInc > 0) body.OrbitInclination = rng.NextFloat(starInc);
                     else body.OrbitInclination = 0;
                 }
 
-                body.RotationPeriod = preferences.GetFloat("rotationMulti", 1f) * random.Next(60, 3600);
-                if (random.NextDouble() < 0.02) body.OrbitalPeriod = -1 * body.OrbitalPeriod; // Clockwise Rotation
+                body.RotationPeriod = preferences.GetFloat("rotationMulti", 1f) * rng.Next(60, 3600);
+                if (rng.NextDouble() < 0.02) body.OrbitalPeriod = -1 * body.OrbitalPeriod; // Clockwise Rotation
                 var innerPlanetDistanceForStar = GetInnerPlanetDistanceForStar(star);
                 // GS2.Warn($"{innerPlanetDistanceForStar} for star {star.Name} {star.displayType}");
                 if (GS2.IsPlanetOfStar(star, body) && body.OrbitRadius < innerPlanetDistanceForStar &&
-                    (random.NextFloat() < 0.5f || preferences.GetBool("tidalLockInnerPlanets")))
+                    (rng.NextFloat() < 0.5f || preferences.GetBool("tidalLockInnerPlanets")))
                     body.RotationPeriod = body.OrbitalPeriod; // Tidal Lock
                 else if (preferences.GetBool("allowResonances", true) && body.OrbitRadius < 1.5f &&
-                         random.NextFloat() < 0.2f)
+                         rng.NextFloat() < 0.2f)
                     body.RotationPeriod = body.OrbitalPeriod / 2; // 1:2 Resonance
                 else if (preferences.GetBool("allowResonances", true) && body.OrbitRadius < 2f &&
-                         random.NextFloat() < 0.1f)
+                         rng.NextFloat() < 0.1f)
                     body.RotationPeriod = body.OrbitalPeriod / 4; // 1:4 Resonance
-                if (random.NextDouble() < 0.05) // Crazy Obliquity
-                    body.Obliquity = random.NextFloat(20f, 85f);
-                if (starInc == -1 && random.NextDouble() < 0.05) // Crazy Inclination
+                if (rng.NextDouble() < 0.05) // Crazy Obliquity
+                    body.Obliquity = rng.NextFloat(20f, 85f);
+                if (starInc == -1 && rng.NextDouble() < 0.05) // Crazy Inclination
                     // GS2.Warn("Setting Crazy Inclination for " + star.Name);
-                    body.OrbitInclination = random.NextFloat(20f, 85f);
+                    body.OrbitInclination = rng.NextFloat(20f, 85f);
 
                 var rc = preferences.GetFloat($"{GetTypeLetterFromStar(star)}rareChance");
                 if (rc > 0f) body.rareChance = rc / 100f;
@@ -385,17 +388,20 @@ namespace GalacticScale.Generators
 
         private void AssignMoonOrbits(GSStar star)
         {
+            // #290: moon-orbit padding rolls used the shared generator-instance rng;
+            // derive a star-scoped stream so they are a pure function of the seed
+            var moonRng = new GS2.Random(GS2.Random.Mix(GSSettings.Seed, star.Seed, 0x6d6f6f6e));
             // Process all planets and recursively assign moon orbits from deepest level first
             for (var planetIndex = 0; planetIndex < star.PlanetCount; planetIndex++)
             {
                 var planet = star.Planets[planetIndex];
-                AssignMoonOrbitsRecursive(planet, 0);
+                AssignMoonOrbitsRecursive(planet, 0, moonRng);
             }
             //Orbits should be set.
             // GS2.Log($"Orbits Set {(birthPlanet != null ? birthPlanet.Name : "null")}");
         }
 
-        private void AssignMoonOrbitsRecursive(GSPlanet host, int depth)
+        private void AssignMoonOrbitsRecursive(GSPlanet host, int depth, GS2.Random rng)
         {
             if (host.Moons == null || host.MoonCount == 0) return;
 
@@ -403,7 +409,7 @@ namespace GalacticScale.Generators
             for (var moonIndex = 0; moonIndex < host.MoonCount; moonIndex++)
             {
                 var moon = host.Moons[moonIndex];
-                AssignMoonOrbitsRecursive(moon, depth + 1);
+                AssignMoonOrbitsRecursive(moon, depth + 1, rng);
             }
 
             // Now assign orbits for this level's moons (after all nested moons are processed)
@@ -411,20 +417,25 @@ namespace GalacticScale.Generators
             {
                 var moon = host.Moons[moonIndex];
                 // Use smaller orbit spacing for deeper nesting levels
-                var baseOrbit = depth == 0 ? GetMoonOrbit() : GetMoonOrbit() / 2f;
+                var baseOrbit = depth == 0 ? GetMoonOrbit(rng) : GetMoonOrbit(rng) / 2f;
                 moon.OrbitRadius = baseOrbit + GetNextAvailableOrbit(host, moonIndex);
                 moon.OrbitalPeriod = Utils.CalculateOrbitPeriod(moon.OrbitRadius);
             }
         }
 
 
-        private float GetMoonOrbit()
+        private float GetMoonOrbit(GS2.Random rng)
         {
-            return 0.01f + random.NextFloat(0f, 0.05f);
+            return 0.01f + rng.NextFloat(0f, 0.05f);
         }
 
         public void SelectPlanetThemes(GSStar star)
         {
+            // #290: theme selection consumed the leftover generator-instance stream,
+            // whose position depended on call counts and boot-scoped iteration order -
+            // the "same slot, different theme on one boot in five" effect. A star-scoped
+            // derived stream makes themes a pure function of the galaxy seed.
+            var rng = new GS2.Random(GS2.Random.Mix(GSSettings.Seed, star.Seed, 0x7468656d));
             foreach (var planet in star.Planets)
             {
                 var heat = CalculateThemeHeat(star, planet.OrbitRadius);
@@ -432,12 +443,12 @@ namespace GalacticScale.Generators
                 if (planet != birthPlanet)
                 {
                     if (planet.Scale == 10f) type = EThemeType.Gas;
-                    planet.Theme = GSSettings.ThemeLibrary.Query(random, type, heat, planet.Radius);
+                    planet.Theme = GSSettings.ThemeLibrary.Query(rng, type, heat, planet.Radius);
                 }
                 else
                 {
                     // GS2.Warn($"Setting Theme for BirthPlanet {birthPlanet.Name}");
-                    var habitableTheme = GSSettings.ThemeLibrary.Query(random, EThemeType.Telluric,
+                    var habitableTheme = GSSettings.ThemeLibrary.Query(rng, EThemeType.Telluric,
                         EThemeHeat.Temperate, preferences.GetInt("birthPlanetSize", 200), EThemeDistribute.Default,
                         true);
                     if (preferences.GetBool("birthPlanetUnlock")) planet.Theme = habitableTheme;
@@ -451,11 +462,11 @@ namespace GalacticScale.Generators
                     {
                         if (body != birthPlanet)
                         {
-                            body.Theme = GSSettings.ThemeLibrary.Query(random, EThemeType.Moon, heat, body.Radius);
+                            body.Theme = GSSettings.ThemeLibrary.Query(rng, EThemeType.Moon, heat, body.Radius);
                         }
                         else
                         {
-                            var habitableTheme = GSSettings.ThemeLibrary.Query(random, EThemeType.Moon,
+                            var habitableTheme = GSSettings.ThemeLibrary.Query(rng, EThemeType.Moon,
                                 EThemeHeat.Temperate, preferences.GetInt("birthPlanetSize", 200),
                                 EThemeDistribute.Default,
                                 true);

--- a/Scripts/Generators/GS2/Settings.cs
+++ b/Scripts/Generators/GS2/Settings.cs
@@ -803,7 +803,7 @@ namespace GalacticScale.Generators
                 // "Random"
                 if (listPosition > 13)
                 {
-                    DotNet35Random random = new();
+                    DotNet35Random random = new(GSSettings.Seed);
                     listPosition = random.Next(13);
                 }
             switch (listPosition)

--- a/Scripts/Generators/GS2/Stars.cs
+++ b/Scripts/Generators/GS2/Stars.cs
@@ -119,7 +119,7 @@ namespace GalacticScale.Generators
             return result;
         }
 
-        private int GetStarMoonSize(GSStar star, int hostRadius, bool hostGas)
+        private int GetStarMoonSize(GSStar star, int hostRadius, bool hostGas, GS2.Random rng)
         {
             if (hostGas) hostRadius *= 10;
             var min = Utils.ParsePlanetSize(GetMinPlanetSizeForStar(star));
@@ -140,7 +140,7 @@ namespace GalacticScale.Generators
             var range = max - min;
             var sd = (float)range / 4;
             //int size = Utils.ParsePlanetSize(random.Next(min, max));
-            var size = Clamp(Utils.ClampedNormalSizeTelluric(random, min, max, GetSizeBiasForStar(star)), min, GetMaxPlanetSizeForStar(star));
+            var size = Clamp(Utils.ClampedNormalSizeTelluric(rng, min, max, GetSizeBiasForStar(star)), min, GetMaxPlanetSizeForStar(star));
             //if (size > hostRadius)
             //{
             //Warn($"MoonSize {size} selected for {star.Name} moon with host size {hostRadius} avg:{average} sd:{sd} max:{max} min:{min} range:{range} hostGas:{hostGas}");
@@ -152,22 +152,22 @@ namespace GalacticScale.Generators
             // return size;
         }
 
-        private int GetStarPlanetSize(GSStar star)
+        private int GetStarPlanetSize(GSStar star, GS2.Random rng)
         {
             // GS2.Warn("GetStarPlanetSize");
             var min = GetMinPlanetSizeForStar(star);
             var max = GetMaxPlanetSizeForStar(star);
             var bias = GetSizeBiasForStar(star);
-            var size = Utils.ClampedNormalSizeTelluric(random, min, max, bias);
+            var size = Utils.ClampedNormalSizeTelluric(rng, min, max, bias);
             return ParsePlanetSize(size);
         }
-        private int GetStarGasSize(GSStar star)
+        private int GetStarGasSize(GSStar star, GS2.Random rng)
         {
             // GS2.Warn("GetStarPlanetSize");
             var min = GetMinGasSizeForStar(star);
             var max = GetMaxGasSizeForStar(star);
             var bias = GetSizeBiasForStar(star);
-            var size = Utils.ClampedNormalSizeGas(random, min, max, bias);
+            var size = Utils.ClampedNormalSizeGas(rng, min, max, bias);
             return ParseGasSize(size);
         }
         private int ParsePlanetSize(int size)

--- a/Scripts/Generators/GS2Dev/GS2Generator.cs
+++ b/Scripts/Generators/GS2Dev/GS2Generator.cs
@@ -134,7 +134,7 @@ namespace GalacticScale.Generators
                         GSSettings.ThemeLibrary.Add("AshenGelisol", Themes.AshenGelisol);
                         Themes.AshenGelisol.Process();
                     }
-                    birthPlanet.Moons.Add(new GSPlanet("Titania McGrath", "AshenGelisol", GetStarMoonSize(birthStar, birthPlanet.Radius, false), 0.02f, 69f, 42069f, 0f, 69f, 420f, 0f, -1f));
+                    birthPlanet.Moons.Add(new GSPlanet("Titania McGrath", "AshenGelisol", GetStarMoonSize(birthStar, birthPlanet.Radius, false, new GS2.Random(GS2.Random.Mix(GSSettings.Seed, birthStar.Seed, 0x746974))), 0.02f, 69f, 42069f, 0f, 69f, 420f, 0f, -1f));
                     return;
                 }
 

--- a/Scripts/Generators/GS2Dev/Planets.cs
+++ b/Scripts/Generators/GS2Dev/Planets.cs
@@ -649,7 +649,7 @@ namespace GalacticScale.Generators
 
             for (var i = 0; i < telluricCount - (isBirthStar && !startOnMoon ? 1 : 0); i++)
             {
-                var radius = GetStarPlanetSize(star);
+                var radius = GetStarPlanetSize(star, random);
                 var p = new GSPlanet("planet_" + i, "Barren", radius, -1, -1, -1, -1, -1, -1, -1, -1, new GSPlanets());
                 p.genData.Add("hosttype", "star");
                 p.genData.Add("hostname", star.Name);
@@ -658,7 +658,7 @@ namespace GalacticScale.Generators
 
             for (var i = 0; i < gasCount; i++)
             {
-                var radius = Mathf.RoundToInt(GetStarGasSize(star) / 10f);
+                var radius = Mathf.RoundToInt(GetStarGasSize(star, random) / 10f);
                 var p = new GSPlanet("planet_" + i, "Gas", radius, -1, -1, -1, -1, -1, -1, -1, -1, new GSPlanets());
                 if (!preferences.GetBool("hugeGasGiants", true)) p.Radius = 80;
                 p.Scale = 10f;
@@ -691,7 +691,7 @@ namespace GalacticScale.Generators
                 }
                 else
                 {
-                    var radius = GetStarPlanetSize(star);
+                    var radius = GetStarPlanetSize(star, random);
                     // GS2.Log("Picking No Host Planet");
                     randomPlanet = new GSPlanet("planet_" + i, "Barren", radius, -1, -1, -1, -1, -1, -1, -1, -1,
                         new GSPlanets());
@@ -700,7 +700,7 @@ namespace GalacticScale.Generators
                     telPlanets.Add(randomPlanet);
                 }
 
-                var moon = new GSPlanet("Moon " + i, "Barren", GetStarMoonSize(star, randomPlanet.Radius, hostGas), -1,
+                var moon = new GSPlanet("Moon " + i, "Barren", GetStarMoonSize(star, randomPlanet.Radius, hostGas, random), -1,
                     -1, -1, -1, -1, -1, -1, -1, new GSPlanets());
                 randomPlanet.Moons.Add(moon);
                 moon.genData.Add("hosttype", "planet");
@@ -739,7 +739,7 @@ namespace GalacticScale.Generators
             {
                 // GS2.Log($"Picking Moon to host Secondary {gasPlanets.Count}/{telPlanets.Count}/{moonCount}/{secondaryMoonCount}");
                 var randomMoon = random.Item(moons);
-                var mm = new GSPlanet("MoonMoon" + i, "Barren", GetStarMoonSize(star, randomMoon.Radius, false), -1, -1,
+                var mm = new GSPlanet("MoonMoon" + i, "Barren", GetStarMoonSize(star, randomMoon.Radius, false, random), -1, -1,
                     -1, -1, -1, -1, -1, -1);
                 mm.genData.Add("hosttype", "moon");
                 mm.genData.Add("hostname", randomMoon.Name);
@@ -784,51 +784,52 @@ namespace GalacticScale.Generators
 
         private void FudgeNumbersForPlanets(GSStar star)
         {
+            var rng = new GS2.Random(GS2.Random.Mix(GSSettings.Seed, star.Seed, 0x66756467));
             // GS2.Warn($"{star.displayType} {star.radius} {star.RadiusAU} {star.luminosity}");
             // GS2.Warn("Star RadiusAU, Star Luminance, HZMin, HZMax, HZ, Orbit Radius, LumInv, LumLin , intensity ");
             foreach (var body in star.Bodies)
             {
-                body.RotationPhase = random.Next(360);
+                body.RotationPhase = rng.Next(360);
                 if (GS2.IsPlanetOfStar(star, body))
                     // GS2.Warn($"SETTING Orbit Inclination of {body.Name} to random");
-                    body.OrbitInclination = random.NextFloat() * 4 + random.NextFloat() * 5;
+                    body.OrbitInclination = rng.NextFloat() * 4 + rng.NextFloat() * 5;
                 if (!GS2.IsPlanetOfStar(star, body))
                     // GS2.Warn($"SETTING Orbit Inclination of {body.Name} to random");
-                    body.OrbitInclination = random.NextFloat() * 50f;
-                body.OrbitPhase = random.Next(360);
-                body.Obliquity = random.NextFloat() * 20;
+                    body.OrbitInclination = rng.NextFloat() * 50f;
+                body.OrbitPhase = rng.Next(360);
+                body.Obliquity = rng.NextFloat() * 20;
                 var starInc = preferences.GetFloat($"{GetTypeLetterFromStar(star)}inclination");
                 var starLong = preferences.GetFloat($"{GetTypeLetterFromStar(star)}orbitLongitude", 0);
                 if (starLong == -1)
-                    body.OrbitLongitude = random.NextFloat() * 360f;
+                    body.OrbitLongitude = rng.NextFloat() * 360f;
                 else
-                    body.OrbitLongitude = random.NextFloat() * starLong;
+                    body.OrbitLongitude = rng.NextFloat() * starLong;
                 // GS2.Log($"StarInc {starInc}");
                 if (GS2.IsPlanetOfStar(star, body) && starInc > -1)
                 {
                     // GS2.Warn($"SETTING starInc Orbit Inclination of {star.Name} to {starInc}");
-                    if (starInc > 0) body.OrbitInclination = random.NextFloat(starInc);
+                    if (starInc > 0) body.OrbitInclination = rng.NextFloat(starInc);
                     else body.OrbitInclination = 0;
                 }
 
-                body.RotationPeriod = preferences.GetFloat("rotationMulti", 1f) * random.Next(60, 3600);
-                if (random.NextDouble() < 0.02) body.OrbitalPeriod = -1 * body.OrbitalPeriod; // Clockwise Rotation
+                body.RotationPeriod = preferences.GetFloat("rotationMulti", 1f) * rng.Next(60, 3600);
+                if (rng.NextDouble() < 0.02) body.OrbitalPeriod = -1 * body.OrbitalPeriod; // Clockwise Rotation
                 var innerPlanetDistanceForStar = GetInnerPlanetDistanceForStar(star);
                 // GS2.Warn($"{innerPlanetDistanceForStar} for star {star.Name} {star.displayType}");
                 if (GS2.IsPlanetOfStar(star, body) && body.OrbitRadius < innerPlanetDistanceForStar &&
-                    (random.NextFloat() < 0.5f || preferences.GetBool("tidalLockInnerPlanets")))
+                    (rng.NextFloat() < 0.5f || preferences.GetBool("tidalLockInnerPlanets")))
                     body.RotationPeriod = body.OrbitalPeriod; // Tidal Lock
                 else if (preferences.GetBool("allowResonances", true) && body.OrbitRadius < 1.5f &&
-                         random.NextFloat() < 0.2f)
+                         rng.NextFloat() < 0.2f)
                     body.RotationPeriod = body.OrbitalPeriod / 2; // 1:2 Resonance
                 else if (preferences.GetBool("allowResonances", true) && body.OrbitRadius < 2f &&
-                         random.NextFloat() < 0.1f)
+                         rng.NextFloat() < 0.1f)
                     body.RotationPeriod = body.OrbitalPeriod / 4; // 1:4 Resonance
-                if (random.NextDouble() < 0.05) // Crazy Obliquity
-                    body.Obliquity = random.NextFloat(20f, 85f);
-                if (starInc == -1 && random.NextDouble() < 0.05) // Crazy Inclination
+                if (rng.NextDouble() < 0.05) // Crazy Obliquity
+                    body.Obliquity = rng.NextFloat(20f, 85f);
+                if (starInc == -1 && rng.NextDouble() < 0.05) // Crazy Inclination
                     // GS2.Warn("Setting Crazy Inclination for " + star.Name);
-                    body.OrbitInclination = random.NextFloat(20f, 85f);
+                    body.OrbitInclination = rng.NextFloat(20f, 85f);
 
                 var rc = preferences.GetFloat($"{GetTypeLetterFromStar(star)}rareChance");
                 if (rc > 0f) body.rareChance = rc / 100f;
@@ -914,17 +915,18 @@ namespace GalacticScale.Generators
 
         private void AssignMoonOrbits(GSStar star)
         {
+            var moonRng = new GS2.Random(GS2.Random.Mix(GSSettings.Seed, star.Seed, 0x6d6f6f6e));
             // Process all planets and recursively assign moon orbits from deepest level first
             for (var planetIndex = 0; planetIndex < star.PlanetCount; planetIndex++)
             {
                 var planet = star.Planets[planetIndex];
-                AssignMoonOrbitsRecursive(planet, 0);
+                AssignMoonOrbitsRecursive(planet, 0, moonRng);
             }
             //Orbits should be set.
             // GS2.Log($"Orbits Set {(birthPlanet != null ? birthPlanet.Name : "null")}");
         }
 
-        private void AssignMoonOrbitsRecursive(GSPlanet host, int depth)
+        private void AssignMoonOrbitsRecursive(GSPlanet host, int depth, GS2.Random rng)
         {
             if (host.Moons == null || host.MoonCount == 0) return;
 
@@ -932,7 +934,7 @@ namespace GalacticScale.Generators
             for (var moonIndex = 0; moonIndex < host.MoonCount; moonIndex++)
             {
                 var moon = host.Moons[moonIndex];
-                AssignMoonOrbitsRecursive(moon, depth + 1);
+                AssignMoonOrbitsRecursive(moon, depth + 1, rng);
             }
 
             // Now assign orbits for this level's moons (after all nested moons are processed)
@@ -940,20 +942,21 @@ namespace GalacticScale.Generators
             {
                 var moon = host.Moons[moonIndex];
                 // Use smaller orbit spacing for deeper nesting levels
-                var baseOrbit = depth == 0 ? GetMoonOrbit() : GetMoonOrbit() / 2f;
+                var baseOrbit = depth == 0 ? GetMoonOrbit(rng) : GetMoonOrbit(rng) / 2f;
                 moon.OrbitRadius = baseOrbit + GetNextAvailableOrbit(host, moonIndex);
                 moon.OrbitalPeriod = Utils.CalculateOrbitPeriod(moon.OrbitRadius);
             }
         }
 
 
-        private float GetMoonOrbit()
+        private float GetMoonOrbit(GS2.Random rng)
         {
-            return 0.01f + random.NextFloat(0f, 0.05f);
+            return 0.01f + rng.NextFloat(0f, 0.05f);
         }
 
         public void SelectPlanetThemes(GSStar star)
         {
+            var rng = new GS2.Random(GS2.Random.Mix(GSSettings.Seed, star.Seed, 0x7468656d));
             foreach (var planet in star.Planets)
             {
                 var heat = CalculateThemeHeat(star, planet.OrbitRadius);
@@ -961,12 +964,12 @@ namespace GalacticScale.Generators
                 if (planet != birthPlanet)
                 {
                     if (planet.Scale == 10f) type = EThemeType.Gas;
-                    planet.Theme = GSSettings.ThemeLibrary.Query(random, type, heat, planet.Radius);
+                    planet.Theme = GSSettings.ThemeLibrary.Query(rng, type, heat, planet.Radius);
                 }
                 else
                 {
                     // GS2.Warn($"Setting Theme for BirthPlanet {birthPlanet.Name}");
-                    var habitableTheme = GSSettings.ThemeLibrary.Query(random, EThemeType.Telluric,
+                    var habitableTheme = GSSettings.ThemeLibrary.Query(rng, EThemeType.Telluric,
                         EThemeHeat.Temperate, preferences.GetInt("birthPlanetSize", 200), EThemeDistribute.Default,
                         true);
                     if (preferences.GetBool("birthPlanetUnlock")) planet.Theme = habitableTheme;
@@ -980,11 +983,11 @@ namespace GalacticScale.Generators
                     {
                         if (body != birthPlanet)
                         {
-                            body.Theme = GSSettings.ThemeLibrary.Query(random, EThemeType.Moon, heat, body.Radius);
+                            body.Theme = GSSettings.ThemeLibrary.Query(rng, EThemeType.Moon, heat, body.Radius);
                         }
                         else
                         {
-                            var habitableTheme = GSSettings.ThemeLibrary.Query(random, EThemeType.Moon,
+                            var habitableTheme = GSSettings.ThemeLibrary.Query(rng, EThemeType.Moon,
                                 EThemeHeat.Temperate, preferences.GetInt("birthPlanetSize", 200),
                                 EThemeDistribute.Default,
                                 true);

--- a/Scripts/Generators/GS2Dev/Stars.cs
+++ b/Scripts/Generators/GS2Dev/Stars.cs
@@ -117,7 +117,7 @@ namespace GalacticScale.Generators
             return result;
         }
 
-        private int GetStarMoonSize(GSStar star, int hostRadius, bool hostGas)
+        private int GetStarMoonSize(GSStar star, int hostRadius, bool hostGas, GS2.Random rng)
         {
             if (hostGas) hostRadius *= 10;
             var min = Utils.ParsePlanetSize(GetMinPlanetSizeForStar(star));
@@ -138,7 +138,7 @@ namespace GalacticScale.Generators
             var range = max - min;
             var sd = (float)range / 4;
             //int size = Utils.ParsePlanetSize(random.Next(min, max));
-            var size = Clamp(Utils.ClampedNormalSizeTelluric(random, min, max, GetSizeBiasForStar(star)), min, GetMaxPlanetSizeForStar(star));
+            var size = Clamp(Utils.ClampedNormalSizeTelluric(rng, min, max, GetSizeBiasForStar(star)), min, GetMaxPlanetSizeForStar(star));
             //if (size > hostRadius)
             //{
             //Warn($"MoonSize {size} selected for {star.Name} moon with host size {hostRadius} avg:{average} sd:{sd} max:{max} min:{min} range:{range} hostGas:{hostGas}");
@@ -150,22 +150,22 @@ namespace GalacticScale.Generators
             // return size;
         }
 
-        private int GetStarPlanetSize(GSStar star)
+        private int GetStarPlanetSize(GSStar star, GS2.Random rng)
         {
             // GS2.Warn("GetStarPlanetSize");
             var min = GetMinPlanetSizeForStar(star);
             var max = GetMaxPlanetSizeForStar(star);
             var bias = GetSizeBiasForStar(star);
-            var size = Utils.ClampedNormalSizeTelluric(random, min, max, bias);
+            var size = Utils.ClampedNormalSizeTelluric(rng, min, max, bias);
             return ParsePlanetSize(size);
         }
-        private int GetStarGasSize(GSStar star)
+        private int GetStarGasSize(GSStar star, GS2.Random rng)
         {
             // GS2.Warn("GetStarPlanetSize");
             var min = GetMinGasSizeForStar(star);
             var max = GetMaxGasSizeForStar(star);
             var bias = GetSizeBiasForStar(star);
-            var size = Utils.ClampedNormalSizeGas(random, min, max, bias);
+            var size = Utils.ClampedNormalSizeGas(rng, min, max, bias);
             return ParseGasSize(size);
         }
         private int ParsePlanetSize(int size)

--- a/Scripts/Models/SystemsNames.cs
+++ b/Scripts/Models/SystemsNames.cs
@@ -1668,15 +1668,23 @@
             "Usteli"
         };
 
+        private static int startIndexSeed = int.MinValue;
+
         public static void Reset()
         {
             var random = new GS2.Random(GSSettings.Seed);
             startIndex = random.Next(names.Length - 1);
+            startIndexSeed = GSSettings.Seed;
         }
 
         public static string GetName(int index)
         {
-            if (startIndex < 0) Reset();
+            // #290: startIndex used to latch once per PROCESS - from whichever galaxy
+            // generated first, which is the TIME-seeded default created when the
+            // galaxy-select screen opens. Names were random per boot, frozen per
+            // session. Re-derive whenever the galaxy seed changes: names become a
+            // pure function of the galaxy seed.
+            if (startIndex < 0 || startIndexSeed != GSSettings.Seed) Reset();
 
             var calcIndex = (index + startIndex) % names.Length;
             return names[calcIndex];

--- a/Scripts/Planet Generation/CreatePlanet.cs
+++ b/Scripts/Planet Generation/CreatePlanet.cs
@@ -29,7 +29,9 @@ namespace GalacticScale
             planet.galaxy = galaxy;
             planet.star = star;
             //if (gsPlanet.Seed < 0) gsPlanet.Seed = random.Next();
-            planet.seed = gsPlanet.Seed = gsPlanet.Seed < 0 ? random.Next() : gsPlanet.Seed;
+            // #290: drawing from the shared ProcessGalaxy rng made planet seeds depend on
+            // how many rolls (hives etc.) preceded them; derive from star seed + index
+            planet.seed = gsPlanet.Seed = gsPlanet.Seed < 0 ? GS2.Random.Mix(GSSettings.Seed, star.seed, index + 1) & 0x7fffffff : gsPlanet.Seed;
             if (isMoon)
             {
                 planet.orbitAround = host.number;

--- a/Scripts/Utils/NameGenerator.cs
+++ b/Scripts/Utils/NameGenerator.cs
@@ -580,7 +580,10 @@ namespace GalacticScale
 
         public static string New(GSPlanet planet)
         {
-            if (r is null) r = new GS2.Random(planet.Seed);
+            // #290: the static rng seeded once per process made "random" planet names
+            // depend on generation history. A fresh per-planet rng is a pure function
+            // of the planet seed.
+            var r = new GS2.Random(planet.Seed);
 
             var c = r.Next(1, 2);
 

--- a/Scripts/Utils/Random.cs
+++ b/Scripts/Utils/Random.cs
@@ -23,6 +23,14 @@ namespace GalacticScale
             {
                 return new Random(increment++);
             }
+
+            // #290: derive a per-object seed from (galaxy seed, object seed, salt) so
+            // every generation roll is a pure function of the galaxy seed - vanilla's
+            // fresh-rng-per-object pattern, order-independent across call sites.
+            public static int Mix(int galaxySeed, int objectSeed, int salt)
+            {
+                unchecked { return galaxySeed * 73856093 ^ objectSeed * 19349663 ^ salt; }
+            }
             public int Seed
             {
                 get => seed;

--- a/Scripts/Vein Generation/GS2.cs
+++ b/Scripts/Vein Generation/GS2.cs
@@ -7,7 +7,12 @@ namespace GalacticScale
 {
     public static partial class VeinAlgorithms
     {
-        public static void GenerateVeinsGS2(GSPlanet gsPlanet) 
+        public static void GenerateVeinsGS2(GSPlanet gsPlanet)
+        {
+            lock (veinGenLock) GenerateVeinsGS2Locked(gsPlanet);
+        }
+
+        private static void GenerateVeinsGS2Locked(GSPlanet gsPlanet) 
         {
             // Debug.Log("Generating");
             random = new GS2.Random(gsPlanet.Seed);

--- a/Scripts/Vein Generation/GS2W.cs
+++ b/Scripts/Vein Generation/GS2W.cs
@@ -2,7 +2,12 @@
 {
     public static partial class VeinAlgorithms
     {
-        public static void GenerateVeinsGS2W(GSPlanet gsPlanet) 
+        public static void GenerateVeinsGS2W(GSPlanet gsPlanet)
+        {
+            lock (veinGenLock) GenerateVeinsGS2WLocked(gsPlanet);
+        }
+
+        private static void GenerateVeinsGS2WLocked(GSPlanet gsPlanet) 
         {
             random = new GS2.Random(gsPlanet.Seed);
             

--- a/Scripts/Vein Generation/GenerateVeins.cs
+++ b/Scripts/Vein Generation/GenerateVeins.cs
@@ -25,10 +25,18 @@ namespace GalacticScale
     public static partial class VeinAlgorithms
     {
         private static GS2.Random random;
+        // #290: vein generation runs on the scan thread, the compute thread and a UI
+        // prefix, all sharing the static rng above. Serializing the entry points keeps
+        // each planet's reseed-at-entry stream uninterleaved, making vein rolls a pure
+        // function of the planet seed regardless of which thread generates it.
+        internal static readonly object veinGenLock = new object();
 
         private static void GenBirthPoints(GSPlanet gsPlanet)
         {
-            random = new GS2.Random(GSSettings.Seed);
+            // #290: this used to REPLACE the shared static rng mid-generation for the
+            // birth planet; a local keeps birth-point rolls galaxy-seeded without
+            // hijacking the planet-seeded vein stream.
+            var random = new GS2.Random(GSSettings.Seed);
             var planet = gsPlanet.planetData;
             // GS2.Log("GenBirthPoints");
             Pose pose;

--- a/Scripts/Vein Generation/Vanilla.cs
+++ b/Scripts/Vein Generation/Vanilla.cs
@@ -6,7 +6,12 @@ namespace GalacticScale
 {
     public static partial class VeinAlgorithms
     {
-        public static void GenerateVeinsVanilla(GSPlanet gsPlanet) //, bool sketchOnly)
+        public static void GenerateVeinsVanilla(GSPlanet gsPlanet)
+        {
+            lock (veinGenLock) GenerateVeinsVanillaLocked(gsPlanet);
+        }
+
+        private static void GenerateVeinsVanillaLocked(GSPlanet gsPlanet) //, bool sketchOnly)
         {
             random = new GS2.Random(gsPlanet.Seed);
             var themeProto = LDB.themes.Select(gsPlanet.planetData.theme);


### PR DESCRIPTION
Fixes #290 — the same seed string now generates the same galaxy every time, including system names, planet themes, and vein amounts, regardless of boot session or how many galaxies were generated before it.

## Root causes

Generation consumed several **process-lifetime RNG streams** whose position depended on history, not the seed:

1. **Vein amounts** — `VeinAlgorithms.random` is static and was re-seeded mid-function on the birth-planet path, plus raced across scan threads. First generation after boot reproduced; later generations drifted.
2. **System names** — `SystemNames.startIndex` was latched once per process by the *time-seeded* default galaxy generated when the galaxy-select screen first opens, so names changed every boot.
3. **Planet size / theme / rotation-fudge / moon orbits** — rolled on the generator-instance stream left over from `GenerateStars`, whose call count varies per boot (dictionary-iteration order), flipping themes roughly 1-in-5 boots.

## Changes

- `GS2.Random.Mix(galaxySeed, objectSeed, salt)` helper; per-star salted streams for themes, rotation fudge, and moon orbits; star-local stream threaded into the planet/gas/moon size pickers.
- Vein generation entry points serialized behind a lock and re-seeded per planet; birth-point generation uses a local seed-derived RNG instead of hijacking the static one.
- `SystemNames` re-Resets whenever `GSSettings.Seed` changes instead of latching the first boot's time-seeded index.
- `CreatePlanet` derives missing planet seeds via `Mix(galaxySeed, star.seed, index+1)` instead of the shared ProcessGalaxy stream.
- Same fixes mirrored into the registered **"Galactic Scale 2 Dev"** generator (`Scripts/Generators/GS2Dev/`), which shares all the same bugs.

## Compatibility

- **Existing saves are unaffected** — loading never re-runs galaxy generation.
- The seed-string → galaxy mapping **changes once** with this release: a seed you generated (but did not save) under an older version will produce a different galaxy now. From this release on, it is stable — which it never actually was before (names and amounts always varied; themes could flip between boots).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
