### PR TITLE
Fix logistics vessels sticking near giant stars

### DIFF
--- a/Scripts/Patches/Transpilers/StationComponent/InternalTickRemote.cs
+++ b/Scripts/Patches/Transpilers/StationComponent/InternalTickRemote.cs
@@ -14,14 +14,21 @@ namespace GalacticScale
         //    Makes planets near huge stars reachable by ship.
         // 3. Fix planet clearance altitude (5000.0) to scale with planet radius
         // 4. Fix warp activation distance (25000000.0 = 5000²) to scale with planet radius
-        // 5. Adjust star radius for pathing calculations to fix issues with large stars
-        // - Updated pattern matching to be more robust and find the correct insertion points
+        // 5. Cap star uRadius for pathing/avoidance so the exclusion bubble around giant stars
+        //    never exceeds the vanilla envelope. Planet radii are far below the cap, so every
+        //    non-star load is untouched.
         // [HarmonyDebug]
         [HarmonyTranspiler]
         [HarmonyPatch(typeof(StationComponent), nameof(StationComponent.InternalTickRemote))]
         public static IEnumerable<CodeInstruction> InternalTickRemoteTranspiler(IEnumerable<CodeInstruction> instructions, ILGenerator il)
         {
-            var codeMatcher = new CodeMatcher(instructions, il).MatchForward(false, new CodeMatch(op => op.opcode == OpCodes.Ldc_I4_S && op.OperandIs(10))); // Search for ldc.i4.s 10
+            // Only the two obstacle-scan loop bounds (ldc.i4.s 10 followed by add) may grow to 100.
+            // The method also uses ldc.i4.s 10 for the far-ship steering throttle (num23 = 10,
+            // stored via stloc); replacing that one made distant vessels update their steering and
+            // obstacle avoidance only every 100 ticks, so they flew blind between corrections.
+            var codeMatcher = new CodeMatcher(instructions, il).MatchForward(false,
+                new CodeMatch(op => op.opcode == OpCodes.Ldc_I4_S && op.OperandIs(10)),
+                new CodeMatch(OpCodes.Add));
 
             if (codeMatcher.IsInvalid)
             {
@@ -29,10 +36,32 @@ namespace GalacticScale
                 return instructions;
             }
 
-            instructions = codeMatcher.Repeat(z => z // Repeat for all occurences 
+            instructions = codeMatcher.Repeat(z => z // Repeat for all occurences
                     .Set(OpCodes.Ldc_I4_S, 100)) // Replace operand with 100
                 .InstructionEnumeration();
             return instructions;
+        }
+
+        [HarmonyTranspiler]
+        [HarmonyPatch(typeof(StationComponent), nameof(StationComponent.InternalTickRemote))]
+        public static IEnumerable<CodeInstruction> InternalTickRemoteTranspiler5_CapStarRadius(IEnumerable<CodeInstruction> instructions)
+        {
+            // Same treatment the DF seekers/relays got in DarkFogRadius: every AstroData.uRadius
+            // read in this method feeds obstacle detection, the star exclusion bubble, or approach
+            // shaping. Cap it at the vanilla max star physics radius so GS2 giant stars do not
+            // project avoidance bubbles that swallow whole planetary orbits (vessels endlessly
+            // circling the bubble edge, unable to reach stations). All planet radii sit far below
+            // the cap, so approach and landing on planets keep the real radius.
+            var radiusField = AccessTools.Field(typeof(AstroData), nameof(AstroData.uRadius));
+            var capMethod = AccessTools.Method(typeof(DarkFogRadius), nameof(DarkFogRadius.CapStarRadiusToVanillaMax));
+            foreach (var code in instructions)
+            {
+                yield return code;
+                if (code.LoadsField(radiusField))
+                {
+                    yield return new CodeInstruction(OpCodes.Call, capMethod);
+                }
+            }
         }
 
         [HarmonyTranspiler]


### PR DESCRIPTION
Fixes logistics vessels getting stuck / endlessly circling near large stars at high star-size multipliers (reported on Discord: "vessels getting stuck around bigger star at higher size multiplier").

Two mechanisms, one symptom, both in `StationComponent.InternalTickRemote`:

## 1. Steering-throttle collateral in the existing scan-window transpiler

The 2022 transpiler that widens the obstacle-scan loops from 10 to 100 astro slots replaced **every** `ldc.i4.s 10` in the method. The method has exactly three: the two scan-loop bounds it meant to change, and the far-flight steering throttle (`num23 = 10` — "update steering every 10th tick"). That third replacement made distant vessels update steering and obstacle avoidance only every **100** ticks, flying blind between corrections — and in giant GS2 systems most of a trip runs in far-flight mode. The matcher now requires the following `add`, so only the two loop bounds are widened (verified against 0.10.34 IL: 2 match, the throttle's `ldc.i4.s 10; stloc` is spared).

## 2. The missing star-radius cap for pathing (the file's promised patch 5)

Giant stars project an avoidance bubble scaled to their `uRadius`. GS2 stars can exceed the vanilla max star physics radius (28320) several times over, so the bubble swallows whole planetary orbits and vessels orbit its edge forever, never reaching stations. Every `AstroData.uRadius` read in `InternalTickRemote` now runs through `DarkFogRadius.CapStarRadiusToVanillaMax` — the identical treatment DF seekers/relays already have. With the existing 2.5→0.5 multiplier patch, the worst-case star bubble is now 14160, which sits inside every real giant star and inside every GS2 planetary orbit. All planet radii are far below the cap, so planet approach/landing keeps real radii (provably a no-op for non-stars).

Verified: builds clean; matcher behavior simulated against the real game IL; adversarial review confirmed transpiler chaining with the other three patches is order-independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
