### PR TITLE
feat(dyson): Dynamic orbit bounds, camera zoom sync, and bullet/rocket speed scaling

### DIFF
--- a/Bootstrap.cs
+++ b/Bootstrap.cs
@@ -90,7 +90,10 @@ namespace GalacticScale
                 harmony.PatchAll(typeof(PatchOnDFRelayComponent));
                 harmony.PatchAll(typeof(PatchOnDFTinderComponent));
                 harmony.PatchAll(typeof(PatchOnDigitalSystem));
-                // harmony.PatchAll(typeof(PatchOnDysonSphere));
+                harmony.PatchAll(typeof(PatchOnDysonSphere));
+                harmony.PatchAll(typeof(PatchOnDysonSwarm));
+                harmony.PatchAll(typeof(PatchOnDysonSphereRocket));
+                harmony.PatchAll(typeof(PatchOnUIDEDialogues));
                 harmony.PatchAll(typeof(PatchOnEnemyDFGroundSystem));
                 harmony.PatchAll(typeof(PatchOnEnemyDFHiveSystem));
                 harmony.PatchAll(typeof(PatchOnFactoryModel));

--- a/Bootstrap.cs
+++ b/Bootstrap.cs
@@ -90,10 +90,7 @@ namespace GalacticScale
                 harmony.PatchAll(typeof(PatchOnDFRelayComponent));
                 harmony.PatchAll(typeof(PatchOnDFTinderComponent));
                 harmony.PatchAll(typeof(PatchOnDigitalSystem));
-                harmony.PatchAll(typeof(PatchOnDysonSphere));
-                harmony.PatchAll(typeof(PatchOnDysonSwarm));
-                harmony.PatchAll(typeof(PatchOnDysonSphereRocket));
-                harmony.PatchAll(typeof(PatchOnUIDEDialogues));
+                // harmony.PatchAll(typeof(PatchOnDysonSphere));
                 harmony.PatchAll(typeof(PatchOnEnemyDFGroundSystem));
                 harmony.PatchAll(typeof(PatchOnEnemyDFHiveSystem));
                 harmony.PatchAll(typeof(PatchOnFactoryModel));

--- a/DevEnv.targets.example
+++ b/DevEnv.targets.example
@@ -1,6 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
 	  <PluginDir>$(AppData)\r2modmanPlus-local\DysonSphereProgram\profiles\Default\BepInEx\plugins</PluginDir>
+	  <GameDir>C:\Program Files (x86)\Steam\steamapps\common\Dyson Sphere Program</GameDir>
   </PropertyGroup>
 </Project>

--- a/GalacticScale3.csproj
+++ b/GalacticScale3.csproj
@@ -54,8 +54,8 @@
             <HintPath>Package\GSUI.dll</HintPath>
         </Reference>
         <Reference Include="UnityEngine.UI">
-          <HintPath Condition="Exists('D:\SteamLibrary\steamapps\common\Dyson Sphere Program\DSPGAME_Data\Managed\UnityEngine.UI.dll')">D:\SteamLibrary\steamapps\common\Dyson Sphere Program\DSPGAME_Data\Managed\UnityEngine.UI.dll</HintPath>
-          <HintPath Condition="!Exists('D:\SteamLibrary\steamapps\common\Dyson Sphere Program\DSPGAME_Data\Managed\UnityEngine.UI.dll')">$(MSBuildThisFileDirectory)..\CommonAPI\Libs\UnityEngine.UI.dll</HintPath>
+          <HintPath Condition="Exists('$(GameDir)\DSPGAME_Data\Managed\UnityEngine.UI.dll')">$(GameDir)\DSPGAME_Data\Managed\UnityEngine.UI.dll</HintPath>
+          <HintPath Condition="!Exists('$(GameDir)\DSPGAME_Data\Managed\UnityEngine.UI.dll')">$(MSBuildThisFileDirectory)..\CommonAPI\Libs\UnityEngine.UI.dll</HintPath>
         </Reference>
     </ItemGroup>
     <Target Name="CheckDevEnv" BeforeTargets="PrepareForBuild">

--- a/GalacticScale3.csproj
+++ b/GalacticScale3.csproj
@@ -54,7 +54,8 @@
             <HintPath>Package\GSUI.dll</HintPath>
         </Reference>
         <Reference Include="UnityEngine.UI">
-          <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Dyson Sphere Program\DSPGAME_Data\Managed\UnityEngine.UI.dll</HintPath>
+          <HintPath Condition="Exists('D:\SteamLibrary\steamapps\common\Dyson Sphere Program\DSPGAME_Data\Managed\UnityEngine.UI.dll')">D:\SteamLibrary\steamapps\common\Dyson Sphere Program\DSPGAME_Data\Managed\UnityEngine.UI.dll</HintPath>
+          <HintPath Condition="!Exists('D:\SteamLibrary\steamapps\common\Dyson Sphere Program\DSPGAME_Data\Managed\UnityEngine.UI.dll')">$(MSBuildThisFileDirectory)..\CommonAPI\Libs\UnityEngine.UI.dll</HintPath>
         </Reference>
     </ItemGroup>
     <Target Name="CheckDevEnv" BeforeTargets="PrepareForBuild">

--- a/Scripts/Models/Star/GSStar.cs
+++ b/Scripts/Models/Star/GSStar.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using UnityEngine;
 
 namespace GalacticScale
@@ -314,9 +314,11 @@ namespace GalacticScale
         private float InitDysonRadius()
         {
             _dysonRadius = StarDefaults.DysonRadius(this);
-            float newRadius = radius * _luminosity * 0.25f;
-            // GS2.Warn($"{Name} Companion:{BinaryCompanion} Luminosity:{_luminosity} Radius:{radius} Dyson Radius Set to {_dysonRadius} -> {newRadius} for {Spectr} spectr star of type {Type}. New Max should be {newRadius*40000}");
-            _dysonRadius = newRadius;
+            float minRadius = RadiusAU + 0.1f;
+            if (_dysonRadius < minRadius)
+            {
+                _dysonRadius = minRadius;
+            }
             return _dysonRadius;
         }
 

--- a/Scripts/Patches/DysonSphere/Init.cs
+++ b/Scripts/Patches/DysonSphere/Init.cs
@@ -114,6 +114,7 @@ namespace GalacticScale
                 __instance.inEditorRenderMaskS = -1;
                 __instance.inGameRenderMaskL = -1;
                 __instance.inGameRenderMaskS = -1;
+                __instance.needRecalculatePower = true;
 
                 return false; // Skip original method
             }

--- a/Scripts/Patches/DysonSphere/Init.cs
+++ b/Scripts/Patches/DysonSphere/Init.cs
@@ -85,16 +85,11 @@ namespace GalacticScale
                         __instance.emissionColor = Configs.builtin.dysonSphereNeutronEmissionColor;
                     }
 
-                    __instance.defOrbitRadius = (float)((double)_starData.dysonRadius * 40000.0);
-                    __instance.minOrbitRadius = _starData.physicsRadius * 1.5f;
-                    if (__instance.minOrbitRadius < 4000f)
-                    {
-                        __instance.minOrbitRadius = 4000f;
-                    }
-                    __instance.maxOrbitRadius = __instance.defOrbitRadius * 2f;
-                    
-                    // Safely handle planets array
-                    if (_starData.planets != null && _starData.planets.Length > 0)
+                    // Calculate and refresh Dyson orbit bounds dynamically
+                    DysonSphereUtils.RefreshDysonOrbitBounds(__instance);
+
+                    // Safely handle avoidOrbitRadius for planet 0
+                    if (_starData.planets != null && _starData.planets.Length > 0 && _starData.planets[0] != null)
                     {
                         __instance.avoidOrbitRadius = (float)((double)_starData.planets[0].orbitRadius * 40000.0);
                     }
@@ -103,14 +98,8 @@ namespace GalacticScale
                         __instance.avoidOrbitRadius = __instance.minOrbitRadius * 1.5f;
                     }
                     
-                    if (_starData.type == EStarType.GiantStar)
-                    {
-                        __instance.minOrbitRadius *= 0.6f;
-                    }
-                    __instance.defOrbitRadius = Mathf.Round(__instance.defOrbitRadius / 100f) * 100f;
-                    __instance.minOrbitRadius = Mathf.Ceil(__instance.minOrbitRadius / 100f) * 100f;
-                    __instance.maxOrbitRadius = Mathf.Round(__instance.maxOrbitRadius / 100f) * 100f;
                     __instance.randSeed = _starData.seed;
+                    GS2.Log($"DysonSphere Initialized for {_starData.name}: Min={__instance.minOrbitRadius}, Def={__instance.defOrbitRadius}, Max={__instance.maxOrbitRadius}");
                 }
 
                 // Initialize swarm after arrays are set up

--- a/Scripts/Patches/DysonSphere/RocketGameTick.cs
+++ b/Scripts/Patches/DysonSphere/RocketGameTick.cs
@@ -9,6 +9,8 @@ namespace GalacticScale
     // Future improvement candidate: convert this speed scaling to a Harmony transpiler patching only the speed/accel constants.
     public class PatchOnDysonSphereRocket
     {
+        private static bool _rocketTickFailed;
+
         [HarmonyPrefix]
         [HarmonyPatch(typeof(DysonSphere), nameof(DysonSphere.RocketGameTick))]
         public static bool RocketGameTick(DysonSphere __instance)
@@ -263,7 +265,11 @@ namespace GalacticScale
             }
             catch (Exception ex)
             {
-                GS2.Warn($"Error in PatchOnDysonSphereRocket.RocketGameTick: {ex.Message}\n{ex.StackTrace}");
+                if (!_rocketTickFailed)
+                {
+                    GS2.Warn($"Error in PatchOnDysonSphereRocket.RocketGameTick: {ex.Message}\n{ex.StackTrace}");
+                    _rocketTickFailed = true;
+                }
                 return false; // Safely abort tick instead of double-ticking previous rockets
             }
         }

--- a/Scripts/Patches/DysonSphere/RocketGameTick.cs
+++ b/Scripts/Patches/DysonSphere/RocketGameTick.cs
@@ -1,0 +1,266 @@
+using System;
+using HarmonyLib;
+using UnityEngine;
+
+namespace GalacticScale
+{
+    public class PatchOnDysonSphereRocket
+    {
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(DysonSphere), nameof(DysonSphere.RocketGameTick))]
+        public static bool RocketGameTick(DysonSphere __instance)
+        {
+            try
+            {
+                if (__instance == null || __instance.starData == null) return true;
+
+                AstroData[] astrosData = __instance.starData.galaxy.astrosData;
+                double num = 1.0 / 60.0;
+
+                // Scale rocket velocity and acceleration dynamically based on system max orbit radius
+                float scaleRatio = Mathf.Max(1f, __instance.maxOrbitRadius / 40000f);
+                float speedMultiplier = Mathf.Pow(scaleRatio, 0.6f);
+
+                float num2 = speedMultiplier;
+                float num3 = 7.5f * speedMultiplier;     // Acceleration scales with system size
+                float num4 = 18f * num2;                 // Deceleration
+                float num5 = 2800f * num2;               // Cruise speed
+                VectorLF3 vectorLF = default(VectorLF3);
+
+                for (int i = 1; i < __instance.rocketCursor; i++)
+                {
+                    if (__instance.rocketPool[i].id != i)
+                    {
+                        continue;
+                    }
+                    ref DysonRocket reference = ref __instance.rocketPool[i];
+                    if (reference.node == null)
+                    {
+                        __instance.RemoveDysonRocket(i);
+                        continue;
+                    }
+
+                    DysonSphereLayer dysonSphereLayer = __instance.layersIdBased[reference.node.layerId];
+                    if (dysonSphereLayer == null)
+                    {
+                        __instance.RemoveDysonRocket(i);
+                        continue;
+                    }
+
+                    ref AstroData reference2 = ref astrosData[reference.planetId];
+                    vectorLF.x = reference2.uPos.x - reference.uPos.x;
+                    vectorLF.y = reference2.uPos.y - reference.uPos.y;
+                    vectorLF.z = reference2.uPos.z - reference.uPos.z;
+                    double num6 = Math.Sqrt(vectorLF.x * vectorLF.x + vectorLF.y * vectorLF.y + vectorLF.z * vectorLF.z) - (double)reference2.uRadius;
+
+                    if (reference.t <= 0f)
+                    {
+                        if (num6 < 200.0)
+                        {
+                            float num7 = (float)num6 / 200f;
+                            if (num7 < 0f) num7 = 0f;
+                            float num8 = num7 * num7 * 600f + 15f;
+                            reference.uSpeed = reference.uSpeed * 0.9f + num8 * 0.1f;
+                            reference.t = (num7 - 1f) * 1.2f;
+                            if (reference.t < -1f) reference.t = -1f;
+                        }
+                        else
+                        {
+                            dysonSphereLayer.NodeEnterUPos(reference.node, out var result);
+                            VectorLF3 vectorLF2 = result - reference.uPos;
+                            double num9 = Math.Sqrt(vectorLF2.x * vectorLF2.x + vectorLF2.y * vectorLF2.y + vectorLF2.z * vectorLF2.z);
+                            if (num9 < 50.0)
+                            {
+                                reference.t = 0.0001f;
+                            }
+                            else
+                            {
+                                reference.t = 0f;
+                            }
+
+                            double num10 = num9 / ((double)reference.uSpeed + 0.1) * 0.382;
+                            double num11 = num9 / (double)num5;
+                            float num12 = (float)((double)reference.uSpeed * num10) + 150f;
+                            if (num12 > num5) num12 = num5;
+
+                            if (reference.uSpeed < num12 - num3)
+                            {
+                                reference.uSpeed += num3;
+                            }
+                            else if (reference.uSpeed > num12 + num4)
+                            {
+                                reference.uSpeed -= num4;
+                            }
+                            else
+                            {
+                                reference.uSpeed = num12;
+                            }
+
+                            int num13 = -1;
+                            double num14 = 0.0;
+                            double num15 = 1E+40;
+                            int num16 = reference.planetId / 100 * 100;
+                            for (int j = num16; j < num16 + 10; j++)
+                            {
+                                float uRadius = astrosData[j].uRadius;
+                                if (!(uRadius < 1f))
+                                {
+                                    VectorLF3 vectorLF3 = reference.uPos - astrosData[j].uPos;
+                                    double num17 = vectorLF3.x * vectorLF3.x + vectorLF3.y * vectorLF3.y + vectorLF3.z * vectorLF3.z;
+                                    double num18 = 0.0 - ((double)reference.uVel.x * vectorLF3.x + (double)reference.uVel.y * vectorLF3.y + (double)reference.uVel.z * vectorLF3.z);
+                                    if ((num18 > 0.0 || num17 < (double)(uRadius * uRadius * 7f)) && num17 < num15)
+                                    {
+                                        num14 = ((num18 < 0.0) ? 0.0 : num18);
+                                        num13 = j;
+                                        num15 = num17;
+                                    }
+                                }
+                            }
+
+                            VectorLF3 vectorLF4 = VectorLF3.zero;
+                            float num19 = 0f;
+                            if (num13 > 0)
+                            {
+                                float num20 = astrosData[num13].uRadius;
+                                bool flag = num13 % 100 == 0;
+                                if (flag)
+                                {
+                                    num20 = dysonSphereLayer.orbitRadius - 400f;
+                                }
+                                double num21 = 1.25;
+                                VectorLF3 vectorLF5 = reference.uPos + (VectorLF3)reference.uVel * num14 - astrosData[num13].uPos;
+                                double num22 = vectorLF5.magnitude / (double)num20;
+                                if (num22 < num21)
+                                {
+                                    double num23 = Math.Sqrt(num15) - (double)num20 * 0.82;
+                                    if (num23 < 1.0) num23 = 1.0;
+                                    double num24 = (num22 - 1.0) / (num21 - 1.0);
+                                    if (num24 < 0.0) num24 = 0.0;
+                                    num24 = 1.0 - num24 * num24;
+                                    double num25 = 0.0;
+                                    num25 = (double)(reference.uSpeed - 6f) / num23 * 2.5 - 0.01;
+                                    if (num25 > 1.5) num25 = 1.5;
+                                    else if (num25 < 0.0) num25 = 0.0;
+                                    num25 = num25 * num25 * num24;
+                                    num19 = (float)(flag ? 0.0 : (num25 * 0.5));
+                                    vectorLF4 = vectorLF5.normalized * num25 * 2.0;
+                                }
+                            }
+
+                            float num26 = 1f / (float)num11 - 0.05f;
+                            num26 += num19;
+                            float num27 = Mathf.Lerp(0.005f, 0.08f, num26);
+                            Vector3 val = Vector3.Slerp(reference.uVel, (Vector3)(vectorLF2.normalized + vectorLF4), num27);
+                            reference.uVel = val.normalized;
+
+                            Quaternion val2;
+                            if (num9 < 350.0)
+                            {
+                                float num28 = ((float)num9 - 50f) / 300f;
+                                val2 = Quaternion.Slerp(dysonSphereLayer.NodeURot(reference.node), Quaternion.LookRotation(reference.uVel), num28);
+                            }
+                            else
+                            {
+                                val2 = Quaternion.LookRotation(reference.uVel);
+                            }
+                            reference.uRot = Quaternion.Slerp(reference.uRot, val2, 0.2f);
+                        }
+                    }
+                    else
+                    {
+                        dysonSphereLayer.NodeSlotUPos(reference.node, out var result2);
+                        VectorLF3 vectorLF6 = result2 - reference.uPos;
+                        double num29 = Math.Sqrt(vectorLF6.x * vectorLF6.x + vectorLF6.y * vectorLF6.y + vectorLF6.z * vectorLF6.z);
+                        if (num29 < 2.0)
+                        {
+                            __instance.ConstructSp(reference.node);
+                            __instance.RemoveDysonRocket(i);
+                            continue;
+                        }
+
+                        float num30 = (float)(num29 * 0.75 + 15.0);
+                        if (num30 > num5) num30 = num5;
+
+                        if (reference.uSpeed < num30 - num3)
+                        {
+                            reference.uSpeed += num3;
+                        }
+                        else if (reference.uSpeed > num30 + num4)
+                        {
+                            reference.uSpeed -= num4;
+                        }
+                        else
+                        {
+                            reference.uSpeed = num30;
+                        }
+
+                        reference.uVel = Vector3.Slerp(reference.uVel, (Vector3)vectorLF6.normalized, 0.1f);
+                        reference.uRot = Quaternion.Slerp(reference.uRot, dysonSphereLayer.NodeURot(reference.node), 0.2f);
+                        reference.t = (350f - (float)num29) / 330f;
+                        if (reference.t > 1f) reference.t = 1f;
+                        else if (reference.t < 0.0001f) reference.t = 0.0001f;
+                    }
+
+                    VectorLF3 vectorLF7 = Vector3.zero;
+                    bool flag2 = false;
+                    double num31 = 2f - (float)num6 / 200f;
+                    if (num31 > 1.0) num31 = 1.0;
+                    else if (num31 < 0.0) num31 = 0.0;
+
+                    if (num31 > 0.0)
+                    {
+                        VectorLF3 v = reference.uPos - reference2.uPos;
+                        VectorLF3 v2 = Maths.QInvRotateLF(reference2.uRot, v);
+                        VectorLF3 vectorLF8 = Maths.QRotateLF(reference2.uRotNext, v2) + reference2.uPosNext;
+                        Quaternion val3 = Quaternion.Inverse(reference2.uRot) * reference.uRot;
+                        Quaternion val4 = reference2.uRotNext * val3;
+                        num31 = (3.0 - num31 - num31) * num31 * num31;
+                        vectorLF7 = (vectorLF8 - reference.uPos) * num31;
+                        reference.uRot = Quaternion.Slerp(reference.uRot, val4, (float)num31);
+                        flag2 = true;
+                    }
+
+                    if (!flag2)
+                    {
+                        VectorLF3 v3 = reference.uPos - __instance.starData.uPosition;
+                        double num32 = Math.Abs(Math.Sqrt(v3.x * v3.x + v3.y * v3.y + v3.z * v3.z) - (double)dysonSphereLayer.orbitRadius);
+                        double num33 = 1.5 - (double)((float)num32 / 1800f);
+                        if (num33 > 1.0) num33 = 1.0;
+                        else if (num33 < 0.0) num33 = 0.0;
+
+                        if (num33 > 0.0)
+                        {
+                            VectorLF3 v4 = Maths.QInvRotateLF(dysonSphereLayer.currentRotation, v3);
+                            VectorLF3 vectorLF9 = Maths.QRotateLF(dysonSphereLayer.nextRotation, v4) + __instance.starData.uPosition;
+                            Quaternion val5 = Quaternion.Inverse(dysonSphereLayer.currentRotation) * reference.uRot;
+                            Quaternion val6 = dysonSphereLayer.nextRotation * val5;
+                            num33 = (3.0 - num33 - num33) * num33 * num33;
+                            vectorLF7 = (vectorLF9 - reference.uPos) * num33;
+                            reference.uRot = Quaternion.Slerp(reference.uRot, val6, (float)num33);
+                        }
+                    }
+
+                    double num34 = (double)reference.uSpeed * num;
+                    reference.uPos.x = reference.uPos.x + (double)reference.uVel.x * num34 + vectorLF7.x;
+                    reference.uPos.y = reference.uPos.y + (double)reference.uVel.y * num34 + vectorLF7.y;
+                    reference.uPos.z = reference.uPos.z + (double)reference.uVel.z * num34 + vectorLF7.z;
+
+                    vectorLF = reference2.uPos - reference.uPos;
+                    num6 = Math.Sqrt(vectorLF.x * vectorLF.x + vectorLF.y * vectorLF.y + vectorLF.z * vectorLF.z) - (double)reference2.uRadius;
+                    if (num6 < 180.0)
+                    {
+                        reference.uPos = reference2.uPos + Maths.QRotateLF(reference2.uRot, (VectorLF3)reference.launch * ((double)reference2.uRadius + num6));
+                        reference.uRot = reference2.uRot * Quaternion.LookRotation(reference.launch);
+                    }
+                }
+
+                return false; // Skip original unscaled method
+            }
+            catch (Exception ex)
+            {
+                GS2.Warn($"Error in PatchOnDysonSphereRocket.RocketGameTick: {ex.Message}\n{ex.StackTrace}");
+                return true;
+            }
+        }
+    }
+}

--- a/Scripts/Patches/DysonSphere/RocketGameTick.cs
+++ b/Scripts/Patches/DysonSphere/RocketGameTick.cs
@@ -4,6 +4,9 @@ using UnityEngine;
 
 namespace GalacticScale
 {
+    // Note: Prefix-return-false replaces DysonSphere.RocketGameTick to dynamically scale rocket speed & acceleration with system envelope.
+    // Any third-party mod transpilers on RocketGameTick (e.g., MoreMegaStructures) will not execute while this prefix is active.
+    // Future improvement candidate: convert this speed scaling to a Harmony transpiler patching only the speed/accel constants.
     public class PatchOnDysonSphereRocket
     {
         [HarmonyPrefix]
@@ -15,6 +18,7 @@ namespace GalacticScale
                 if (__instance == null || __instance.starData == null) return true;
 
                 AstroData[] astrosData = __instance.starData.galaxy.astrosData;
+                if (astrosData == null) return true;
                 double num = 1.0 / 60.0;
 
                 // Scale rocket velocity and acceleration dynamically based on system max orbit radius
@@ -100,7 +104,8 @@ namespace GalacticScale
                             double num14 = 0.0;
                             double num15 = 1E+40;
                             int num16 = reference.planetId / 100 * 100;
-                            for (int j = num16; j < num16 + 10; j++)
+                            int maxAstro = Math.Min(num16 + 100, astrosData.Length);
+                            for (int j = num16; j < maxAstro; j++)
                             {
                                 float uRadius = astrosData[j].uRadius;
                                 if (!(uRadius < 1f))

--- a/Scripts/Patches/DysonSphere/RocketGameTick.cs
+++ b/Scripts/Patches/DysonSphere/RocketGameTick.cs
@@ -259,7 +259,7 @@ namespace GalacticScale
             catch (Exception ex)
             {
                 GS2.Warn($"Error in PatchOnDysonSphereRocket.RocketGameTick: {ex.Message}\n{ex.StackTrace}");
-                return true;
+                return false; // Safely abort tick instead of double-ticking previous rockets
             }
         }
     }

--- a/Scripts/Patches/DysonSphere/SailBulletPatch.cs
+++ b/Scripts/Patches/DysonSphere/SailBulletPatch.cs
@@ -1,0 +1,24 @@
+using HarmonyLib;
+using UnityEngine;
+
+namespace GalacticScale
+{
+    public class PatchOnDysonSwarm
+    {
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(DysonSwarm), nameof(DysonSwarm.AddBullet))]
+        public static void AddBullet(ref SailBullet bullet, int orbitId)
+        {
+            VectorLF3 delta = bullet.uEnd - bullet.uBegin;
+            float targetDist = (float)delta.magnitude;
+            if (targetDist > 1000f)
+            {
+                // Scale bullet velocity: v = 5000 * sqrt(targetDist / 40000)
+                // Keeps flight time within ~8s - 25s across systems of all sizes
+                float speedMultiplier = Mathf.Max(1.0f, Mathf.Sqrt(targetDist / 40000.0f));
+                float scaledSpeed = 5000.0f * speedMultiplier;
+                bullet.maxt = targetDist / scaledSpeed;
+            }
+        }
+    }
+}

--- a/Scripts/Patches/DysonSphere/UIDEDialoguePatch.cs
+++ b/Scripts/Patches/DysonSphere/UIDEDialoguePatch.cs
@@ -222,7 +222,8 @@ namespace GalacticScale
                     var p = __instance.starData.planets[i];
                     if (p != null && p.orbitRadius > 0f)
                     {
-                        float pOrbit = (float)((double)p.orbitRadius * 40000.0);
+                        float pOrbitAU = p.orbitAround != 0 && p.orbitAroundPlanet != null ? p.orbitAroundPlanet.orbitRadius : p.orbitRadius;
+                        float pOrbit = (float)((double)pOrbitAU * 40000.0);
                         if (Mathf.Abs(pOrbit - swarmRadius) < 2199.95f)
                         {
                             __result = -2;
@@ -252,7 +253,8 @@ namespace GalacticScale
                     var p = __instance.starData.planets[i];
                     if (p != null && p.orbitRadius > 0f)
                     {
-                        float pOrbit = (float)((double)p.orbitRadius * 40000.0);
+                        float pOrbitAU = p.orbitAround != 0 && p.orbitAroundPlanet != null ? p.orbitAroundPlanet.orbitRadius : p.orbitRadius;
+                        float pOrbit = (float)((double)pOrbitAU * 40000.0);
                         if (Mathf.Abs(pOrbit - orbitRadius) < 2199.95f)
                         {
                             __result = -2;
@@ -263,7 +265,7 @@ namespace GalacticScale
             }
             if (__instance.layersSorted != null)
             {
-                for (int j = 0; j < 10; j++)
+                for (int j = 0; j < __instance.layersSorted.Length; j++)
                 {
                     if (__instance.layersSorted[j] != null && Mathf.Abs(__instance.layersSorted[j].orbitRadius - orbitRadius) < 999.95f)
                     {
@@ -295,9 +297,26 @@ namespace GalacticScale
             if (orbitRadius < __instance.minOrbitRadius) orbitRadius = __instance.minOrbitRadius;
             if (orbitRadius > __instance.maxOrbitRadius) orbitRadius = __instance.maxOrbitRadius;
 
+            if (__instance.starData?.planets != null)
+            {
+                for (int i = 0; i < __instance.starData.planets.Length; i++)
+                {
+                    var p = __instance.starData.planets[i];
+                    if (p != null && p.orbitRadius > 0f)
+                    {
+                        float pOrbitAU = p.orbitAround != 0 && p.orbitAroundPlanet != null ? p.orbitAroundPlanet.orbitRadius : p.orbitRadius;
+                        float pOrbit = (float)((double)pOrbitAU * 40000.0);
+                        if (Mathf.Abs(pOrbit - orbitRadius) < 2199.95f)
+                        {
+                            orbitRadius = Mathf.Ceil(pOrbit + 2200f);
+                        }
+                    }
+                }
+            }
+
             if (__instance.layersSorted != null)
             {
-                for (int i = 0; i < 10; i++)
+                for (int i = 0; i < __instance.layersSorted.Length; i++)
                 {
                     if (__instance.layersSorted[i] != null && Mathf.Abs(__instance.layersSorted[i].orbitRadius - orbitRadius) < 999.95f)
                     {

--- a/Scripts/Patches/DysonSphere/UIDEDialoguePatch.cs
+++ b/Scripts/Patches/DysonSphere/UIDEDialoguePatch.cs
@@ -1,0 +1,318 @@
+using System;
+using HarmonyLib;
+using UnityEngine;
+
+namespace GalacticScale
+{
+    public static class DysonSphereUtils
+    {
+        public static void RefreshDysonOrbitBounds(DysonSphere dysonSphere)
+        {
+            if (dysonSphere == null || dysonSphere.starData == null) return;
+            StarData starData = dysonSphere.starData;
+
+            // 1. Min Orbit Radius = Star Physics Radius + 0.1 AU (4000m)
+            dysonSphere.minOrbitRadius = starData.physicsRadius + 4000f;
+            if (dysonSphere.minOrbitRadius < 4000f)
+            {
+                dysonSphere.minOrbitRadius = 4000f;
+            }
+
+            // 2. Max Orbit Radius = Farthest planet orbit + 1.0 AU (40000m)
+            float maxPlanetOrbitMeters = 0f;
+            if (starData.planets != null && starData.planets.Length > 0)
+            {
+                for (int i = 0; i < starData.planets.Length; i++)
+                {
+                    if (starData.planets[i] != null && starData.planets[i].orbitRadius > 0f)
+                    {
+                        float pOrbitAU = starData.planets[i].orbitAround != 0 && starData.planets[i].orbitAroundPlanet != null
+                            ? starData.planets[i].orbitAroundPlanet.orbitRadius
+                            : starData.planets[i].orbitRadius;
+                        float pOrbit = (float)((double)pOrbitAU * 40000.0);
+                        if (pOrbit > maxPlanetOrbitMeters)
+                        {
+                            maxPlanetOrbitMeters = pOrbit;
+                        }
+                    }
+                }
+            }
+
+            if (maxPlanetOrbitMeters > 0f)
+            {
+                dysonSphere.maxOrbitRadius = maxPlanetOrbitMeters + 40000f; // Farthest planet + 1.0 AU
+            }
+            else
+            {
+                dysonSphere.maxOrbitRadius = dysonSphere.minOrbitRadius + 40000f; // Fallback: min + 1.0 AU
+            }
+
+            if (dysonSphere.maxOrbitRadius < dysonSphere.minOrbitRadius + 4000f)
+            {
+                dysonSphere.maxOrbitRadius = dysonSphere.minOrbitRadius + 4000f;
+            }
+
+            // 3. Default Orbit Radius: comfortable 25% zone between min and max
+            dysonSphere.defOrbitRadius = dysonSphere.minOrbitRadius + (dysonSphere.maxOrbitRadius - dysonSphere.minOrbitRadius) * 0.25f;
+            dysonSphere.defOrbitRadius = Mathf.Round(dysonSphere.defOrbitRadius / 100f) * 100f;
+            dysonSphere.minOrbitRadius = Mathf.Ceil(dysonSphere.minOrbitRadius / 100f) * 100f;
+            dysonSphere.maxOrbitRadius = Mathf.Round(dysonSphere.maxOrbitRadius / 100f) * 100f;
+        }
+    }
+
+    public class PatchOnUIDEDialogues
+    {
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(UIDysonEditor), nameof(UIDysonEditor.OnViewStarChange))]
+        public static void UIDysonEditor_OnViewStarChange_Prefix(UIDysonEditor __instance)
+        {
+            if (__instance != null && __instance.selection != null && __instance.selection.viewDysonSphere != null)
+            {
+                DysonSphereUtils.RefreshDysonOrbitBounds(__instance.selection.viewDysonSphere);
+            }
+        }
+
+        [HarmonyPostfix]
+        [HarmonyPatch(typeof(UIDysonEditor), nameof(UIDysonEditor.OnViewStarChange))]
+        public static void UIDysonEditor_OnViewStarChange_Postfix(UIDysonEditor __instance)
+        {
+            if (__instance == null || __instance.selection == null || __instance.selection.viewDysonSphere == null || __instance.cameraController == null) return;
+            
+            var dysonSphere = __instance.selection.viewDysonSphere;
+            var star = __instance.selection.viewStar;
+            if (star == null) return;
+
+            // Recalibrate Camera distance & clipping planes based on actual maxOrbitRadius
+            float maxOrbitUnity = dysonSphere.maxOrbitRadius * 0.00025f;
+            float defOrbitUnity = dysonSphere.defOrbitRadius * 0.00025f;
+            float starPhysicsUnity = (float)((double)star.physicsRadius * 0.00025 * 2.0);
+
+            __instance.cameraController.minDist = Mathf.Max(5f, starPhysicsUnity * 0.8f);
+            __instance.cameraController.maxDist = Mathf.Max(maxOrbitUnity * 3.5f, 300f);
+            
+            float targetDist = Mathf.Max(defOrbitUnity * 2.6f, __instance.cameraController.minDist * 1.5f);
+            __instance.cameraController.dist = targetDist;
+            __instance.cameraController.distWanted = targetDist;
+
+            if (__instance.screenCamera != null)
+            {
+                __instance.screenCamera.nearClipPlane = Mathf.Min(0.5f, __instance.cameraController.minDist * 0.1f);
+                __instance.screenCamera.farClipPlane = __instance.cameraController.maxDist * 2.5f;
+            }
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(UIDEAddSwarmDialogue), nameof(UIDEAddSwarmDialogue.OnViewStarChange))]
+        public static void SwarmOnViewStarChange_Prefix(UIDEAddSwarmDialogue __instance, DysonSphere dysonSphere)
+        {
+            if (dysonSphere != null)
+            {
+                DysonSphereUtils.RefreshDysonOrbitBounds(dysonSphere);
+            }
+        }
+
+        [HarmonyPostfix]
+        [HarmonyPatch(typeof(UIDEAddSwarmDialogue), nameof(UIDEAddSwarmDialogue.OnViewStarChange))]
+        public static void SwarmOnViewStarChange_Postfix(UIDEAddSwarmDialogue __instance, DysonSphere dysonSphere)
+        {
+            if (dysonSphere != null && __instance.slider0 != null)
+            {
+                __instance.slider0.minValue = dysonSphere.minOrbitRadius;
+                __instance.slider0.maxValue = dysonSphere.maxOrbitRadius;
+                __instance.slider0.value = Mathf.Clamp(dysonSphere.defOrbitRadius, __instance.slider0.minValue, __instance.slider0.maxValue);
+                if (__instance.input0 != null)
+                {
+                    __instance.input0.text = __instance.slider0.value.ToString("0");
+                }
+            }
+        }
+
+        [HarmonyPostfix]
+        [HarmonyPatch(typeof(UIDEAddSwarmDialogue), "_OnOpen")]
+        public static void SwarmOnOpen_Postfix(UIDEAddSwarmDialogue __instance)
+        {
+            if (__instance != null && __instance.editor != null && __instance.editor.cameraController != null && __instance.slider0 != null)
+            {
+                float targetOrbitUnity = __instance.slider0.value * 0.00025f;
+                __instance.editor.cameraController.distWanted = Mathf.Max(__instance.editor.cameraController.distWanted, targetOrbitUnity * 2.6f);
+            }
+        }
+
+        [HarmonyPostfix]
+        [HarmonyPatch(typeof(UIDEAddSwarmDialogue), nameof(UIDEAddSwarmDialogue.OnSlider0Change))]
+        public static void SwarmOnSlider0Change_Postfix(UIDEAddSwarmDialogue __instance, float val)
+        {
+            if (__instance != null && __instance.editor != null && __instance.editor.cameraController != null)
+            {
+                float targetOrbitUnity = val * 0.00025f;
+                float neededDist = targetOrbitUnity * 2.6f;
+                if (__instance.editor.cameraController.distWanted < neededDist)
+                {
+                    __instance.editor.cameraController.distWanted = neededDist;
+                }
+            }
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(UIDEAddLayerDialogue), nameof(UIDEAddLayerDialogue.OnViewStarChange))]
+        public static void LayerOnViewStarChange_Prefix(UIDEAddLayerDialogue __instance, DysonSphere dysonSphere)
+        {
+            if (dysonSphere != null)
+            {
+                DysonSphereUtils.RefreshDysonOrbitBounds(dysonSphere);
+            }
+        }
+
+        [HarmonyPostfix]
+        [HarmonyPatch(typeof(UIDEAddLayerDialogue), nameof(UIDEAddLayerDialogue.OnViewStarChange))]
+        public static void LayerOnViewStarChange_Postfix(UIDEAddLayerDialogue __instance, DysonSphere dysonSphere)
+        {
+            if (dysonSphere != null && __instance.slider0 != null)
+            {
+                __instance.slider0.minValue = dysonSphere.minOrbitRadius;
+                __instance.slider0.maxValue = dysonSphere.maxOrbitRadius;
+                __instance.slider0.value = Mathf.Clamp(dysonSphere.defOrbitRadius, __instance.slider0.minValue, __instance.slider0.maxValue);
+                if (__instance.input0 != null)
+                {
+                    __instance.input0.text = __instance.slider0.value.ToString("0");
+                }
+            }
+        }
+
+        [HarmonyPostfix]
+        [HarmonyPatch(typeof(UIDEAddLayerDialogue), "_OnOpen")]
+        public static void LayerOnOpen_Postfix(UIDEAddLayerDialogue __instance)
+        {
+            if (__instance != null && __instance.editor != null && __instance.editor.cameraController != null && __instance.slider0 != null)
+            {
+                float targetOrbitUnity = __instance.slider0.value * 0.00025f;
+                __instance.editor.cameraController.distWanted = Mathf.Max(__instance.editor.cameraController.distWanted, targetOrbitUnity * 2.6f);
+            }
+        }
+
+        [HarmonyPostfix]
+        [HarmonyPatch(typeof(UIDEAddLayerDialogue), nameof(UIDEAddLayerDialogue.OnSlider0Change))]
+        public static void LayerOnSlider0Change_Postfix(UIDEAddLayerDialogue __instance, float val)
+        {
+            if (__instance != null && __instance.editor != null && __instance.editor.cameraController != null)
+            {
+                float targetOrbitUnity = val * 0.00025f;
+                float neededDist = targetOrbitUnity * 2.6f;
+                if (__instance.editor.cameraController.distWanted < neededDist)
+                {
+                    __instance.editor.cameraController.distWanted = neededDist;
+                }
+            }
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(DysonSphere), nameof(DysonSphere.CheckSwarmRadius))]
+        public static bool CheckSwarmRadius(DysonSphere __instance, float swarmRadius, ref int __result)
+        {
+            DysonSphereUtils.RefreshDysonOrbitBounds(__instance);
+            if (swarmRadius < __instance.minOrbitRadius || swarmRadius > __instance.maxOrbitRadius)
+            {
+                __result = -3;
+                return false;
+            }
+            if (__instance.starData?.planets != null)
+            {
+                for (int i = 0; i < __instance.starData.planets.Length; i++)
+                {
+                    var p = __instance.starData.planets[i];
+                    if (p != null && p.orbitRadius > 0f)
+                    {
+                        float pOrbit = (float)((double)p.orbitRadius * 40000.0);
+                        if (Mathf.Abs(pOrbit - swarmRadius) < 2199.95f)
+                        {
+                            __result = -2;
+                            return false;
+                        }
+                    }
+                }
+            }
+            __result = 0;
+            return false;
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(DysonSphere), nameof(DysonSphere.CheckLayerRadius))]
+        public static bool CheckLayerRadius(DysonSphere __instance, float orbitRadius, ref int __result)
+        {
+            DysonSphereUtils.RefreshDysonOrbitBounds(__instance);
+            if (orbitRadius < __instance.minOrbitRadius || orbitRadius > __instance.maxOrbitRadius)
+            {
+                __result = -3;
+                return false;
+            }
+            if (__instance.starData?.planets != null)
+            {
+                for (int i = 0; i < __instance.starData.planets.Length; i++)
+                {
+                    var p = __instance.starData.planets[i];
+                    if (p != null && p.orbitRadius > 0f)
+                    {
+                        float pOrbit = (float)((double)p.orbitRadius * 40000.0);
+                        if (Mathf.Abs(pOrbit - orbitRadius) < 2199.95f)
+                        {
+                            __result = -2;
+                            return false;
+                        }
+                    }
+                }
+            }
+            if (__instance.layersSorted != null)
+            {
+                for (int j = 0; j < 10; j++)
+                {
+                    if (__instance.layersSorted[j] != null && Mathf.Abs(__instance.layersSorted[j].orbitRadius - orbitRadius) < 999.95f)
+                    {
+                        __result = -1;
+                        return false;
+                    }
+                }
+            }
+            __result = 0;
+            return false;
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(DysonSphere), nameof(DysonSphere.QuerySwarmRadius))]
+        public static bool QuerySwarmRadius(DysonSphere __instance, ref float orbitRadius)
+        {
+            DysonSphereUtils.RefreshDysonOrbitBounds(__instance);
+            if (orbitRadius < __instance.minOrbitRadius) orbitRadius = __instance.minOrbitRadius;
+            if (orbitRadius > __instance.maxOrbitRadius) orbitRadius = __instance.maxOrbitRadius;
+            return false;
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(DysonSphere), nameof(DysonSphere.QueryLayerRadius))]
+        public static bool QueryLayerRadius(DysonSphere __instance, ref float orbitRadius, out float orbitAngularSpeed, ref bool __result)
+        {
+            DysonSphereUtils.RefreshDysonOrbitBounds(__instance);
+            orbitAngularSpeed = 0f;
+            if (orbitRadius < __instance.minOrbitRadius) orbitRadius = __instance.minOrbitRadius;
+            if (orbitRadius > __instance.maxOrbitRadius) orbitRadius = __instance.maxOrbitRadius;
+
+            if (__instance.layersSorted != null)
+            {
+                for (int i = 0; i < 10; i++)
+                {
+                    if (__instance.layersSorted[i] != null && Mathf.Abs(__instance.layersSorted[i].orbitRadius - orbitRadius) < 999.95f)
+                    {
+                        orbitRadius = Mathf.Ceil(__instance.layersSorted[i].orbitRadius + 1000f);
+                    }
+                }
+            }
+            if (orbitRadius > __instance.maxOrbitRadius)
+            {
+                orbitRadius = __instance.maxOrbitRadius;
+                __result = false;
+                return false;
+            }
+            __result = true;
+            return false;
+        }
+    }
+}

--- a/Scripts/Patches/DysonSphere/UIDEDialoguePatch.cs
+++ b/Scripts/Patches/DysonSphere/UIDEDialoguePatch.cs
@@ -47,6 +47,18 @@ namespace GalacticScale
                 dysonSphere.maxOrbitRadius = dysonSphere.minOrbitRadius + 40000f; // Fallback: min + 1.0 AU
             }
 
+            // Legacy saves: spheres built under older formulas may have layers exceeding new bounds
+            if (dysonSphere.layersSorted != null)
+            {
+                for (int i = 0; i < dysonSphere.layersSorted.Length; i++)
+                {
+                    if (dysonSphere.layersSorted[i] != null && dysonSphere.layersSorted[i].orbitRadius + 4000f > dysonSphere.maxOrbitRadius)
+                    {
+                        dysonSphere.maxOrbitRadius = dysonSphere.layersSorted[i].orbitRadius + 4000f;
+                    }
+                }
+            }
+
             if (dysonSphere.maxOrbitRadius < dysonSphere.minOrbitRadius + 4000f)
             {
                 dysonSphere.maxOrbitRadius = dysonSphere.minOrbitRadius + 4000f;
@@ -285,17 +297,6 @@ namespace GalacticScale
             DysonSphereUtils.RefreshDysonOrbitBounds(__instance);
             if (orbitRadius < __instance.minOrbitRadius) orbitRadius = __instance.minOrbitRadius;
             if (orbitRadius > __instance.maxOrbitRadius) orbitRadius = __instance.maxOrbitRadius;
-            return false;
-        }
-
-        [HarmonyPrefix]
-        [HarmonyPatch(typeof(DysonSphere), nameof(DysonSphere.QueryLayerRadius))]
-        public static bool QueryLayerRadius(DysonSphere __instance, ref float orbitRadius, out float orbitAngularSpeed, ref bool __result)
-        {
-            DysonSphereUtils.RefreshDysonOrbitBounds(__instance);
-            orbitAngularSpeed = 0f;
-            if (orbitRadius < __instance.minOrbitRadius) orbitRadius = __instance.minOrbitRadius;
-            if (orbitRadius > __instance.maxOrbitRadius) orbitRadius = __instance.maxOrbitRadius;
 
             if (__instance.starData?.planets != null)
             {
@@ -308,28 +309,169 @@ namespace GalacticScale
                         float pOrbit = (float)((double)pOrbitAU * 40000.0);
                         if (Mathf.Abs(pOrbit - orbitRadius) < 2199.95f)
                         {
-                            orbitRadius = Mathf.Ceil(pOrbit + 2200f);
+                            if (orbitRadius < pOrbit)
+                            {
+                                orbitRadius = Mathf.Floor(pOrbit - 2200f);
+                            }
+                            else
+                            {
+                                orbitRadius = Mathf.Ceil(pOrbit + 2200f);
+                            }
                         }
                     }
                 }
             }
 
-            if (__instance.layersSorted != null)
+            if (orbitRadius < __instance.minOrbitRadius) orbitRadius = __instance.minOrbitRadius;
+            if (orbitRadius > __instance.maxOrbitRadius) orbitRadius = __instance.maxOrbitRadius;
+            return false;
+        }
+
+        private static float PushLayersCeil(DysonSphere dysonSphere, float radius)
+        {
+            if (dysonSphere.layersSorted != null)
             {
-                for (int i = 0; i < __instance.layersSorted.Length; i++)
+                for (int i = 0; i < dysonSphere.layersSorted.Length; i++)
                 {
-                    if (__instance.layersSorted[i] != null && Mathf.Abs(__instance.layersSorted[i].orbitRadius - orbitRadius) < 999.95f)
+                    var layer = dysonSphere.layersSorted[i];
+                    if (layer != null && Mathf.Abs(layer.orbitRadius - radius) < 999.95f)
                     {
-                        orbitRadius = Mathf.Ceil(__instance.layersSorted[i].orbitRadius + 1000f);
+                        radius = Mathf.Ceil(layer.orbitRadius + 1000f);
                     }
                 }
             }
-            if (orbitRadius > __instance.maxOrbitRadius)
+            return radius;
+        }
+
+        private static float PushLayersFloor(DysonSphere dysonSphere, float radius)
+        {
+            if (dysonSphere.layersSorted != null)
             {
-                orbitRadius = __instance.maxOrbitRadius;
+                for (int i = dysonSphere.layersSorted.Length - 1; i >= 0; i--)
+                {
+                    var layer = dysonSphere.layersSorted[i];
+                    if (layer != null && Mathf.Abs(layer.orbitRadius - radius) < 999.95f)
+                    {
+                        radius = Mathf.Floor(layer.orbitRadius - 1000f);
+                    }
+                }
+            }
+            return radius;
+        }
+
+        private static float PushPlanetsCeil(DysonSphere dysonSphere, float radius)
+        {
+            if (dysonSphere.starData?.planets != null)
+            {
+                for (int i = 0; i < dysonSphere.starData.planets.Length; i++)
+                {
+                    var p = dysonSphere.starData.planets[i];
+                    if (p != null && p.orbitRadius > 0f)
+                    {
+                        float pOrbitAU = p.orbitAround != 0 && p.orbitAroundPlanet != null ? p.orbitAroundPlanet.orbitRadius : p.orbitRadius;
+                        float pOrbit = (float)((double)pOrbitAU * 40000.0);
+                        if (Mathf.Abs(pOrbit - radius) < 2199.95f)
+                        {
+                            radius = Mathf.Ceil(pOrbit + 2200f);
+                        }
+                    }
+                }
+            }
+            return radius;
+        }
+
+        private static float PushPlanetsFloor(DysonSphere dysonSphere, float radius)
+        {
+            if (dysonSphere.starData?.planets != null)
+            {
+                for (int i = dysonSphere.starData.planets.Length - 1; i >= 0; i--)
+                {
+                    var p = dysonSphere.starData.planets[i];
+                    if (p != null && p.orbitRadius > 0f)
+                    {
+                        float pOrbitAU = p.orbitAround != 0 && p.orbitAroundPlanet != null ? p.orbitAroundPlanet.orbitRadius : p.orbitRadius;
+                        float pOrbit = (float)((double)pOrbitAU * 40000.0);
+                        if (Mathf.Abs(pOrbit - radius) < 2199.95f)
+                        {
+                            radius = Mathf.Floor(pOrbit - 2200f);
+                        }
+                    }
+                }
+            }
+            return radius;
+        }
+
+        private static float ComputeAngularSpeed(float gravity, float orbitRadius)
+        {
+            if (orbitRadius <= 0f || gravity <= 0f) return 0f;
+            return Mathf.Sqrt(gravity / orbitRadius) / orbitRadius * 57.29578f;
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(DysonSphere), nameof(DysonSphere.QueryLayerRadius))]
+        public static bool QueryLayerRadius(DysonSphere __instance, ref float orbitRadius, out float orbitAngularSpeed, ref bool __result)
+        {
+            DysonSphereUtils.RefreshDysonOrbitBounds(__instance);
+            orbitAngularSpeed = 0f;
+
+            if (orbitRadius < __instance.minOrbitRadius) orbitRadius = __instance.minOrbitRadius;
+            if (orbitRadius > __instance.maxOrbitRadius) orbitRadius = __instance.maxOrbitRadius;
+
+            float requestedRadius = orbitRadius;
+
+            // Pass 1: Forward-first search (push outward, then inward if needed)
+            float cand1 = requestedRadius;
+            cand1 = PushLayersCeil(__instance, cand1);
+            cand1 = PushPlanetsCeil(__instance, cand1);
+            cand1 = PushLayersCeil(__instance, cand1);
+            if (cand1 > __instance.maxOrbitRadius)
+            {
+                cand1 = __instance.maxOrbitRadius;
+            }
+            cand1 = PushLayersFloor(__instance, cand1);
+            cand1 = PushPlanetsFloor(__instance, cand1);
+            cand1 = PushLayersFloor(__instance, cand1);
+
+            if (cand1 < __instance.minOrbitRadius)
+            {
+                orbitRadius = __instance.minOrbitRadius;
+                orbitAngularSpeed = ComputeAngularSpeed(__instance.gravity, orbitRadius);
                 __result = false;
                 return false;
             }
+
+            // Pass 2: Backward-first search (push inward, then outward if needed)
+            float cand2 = requestedRadius;
+            cand2 = PushLayersFloor(__instance, cand2);
+            cand2 = PushPlanetsFloor(__instance, cand2);
+            cand2 = PushLayersFloor(__instance, cand2);
+            if (cand2 < __instance.minOrbitRadius)
+            {
+                cand2 = __instance.minOrbitRadius;
+            }
+            cand2 = PushLayersCeil(__instance, cand2);
+            cand2 = PushPlanetsCeil(__instance, cand2);
+            cand2 = PushLayersCeil(__instance, cand2);
+
+            if (cand2 > __instance.maxOrbitRadius)
+            {
+                orbitRadius = __instance.minOrbitRadius;
+                orbitAngularSpeed = ComputeAngularSpeed(__instance.gravity, orbitRadius);
+                __result = false;
+                return false;
+            }
+
+            // Select candidate closest to the originally requested radius
+            if (Mathf.Abs(cand1 - requestedRadius) < Mathf.Abs(cand2 - requestedRadius))
+            {
+                orbitRadius = cand1;
+            }
+            else
+            {
+                orbitRadius = cand2;
+            }
+
+            orbitAngularSpeed = ComputeAngularSpeed(__instance.gravity, orbitRadius);
             __result = true;
             return false;
         }

--- a/Scripts/Patches/DysonSphere/UIDEDialoguePatch.cs
+++ b/Scripts/Patches/DysonSphere/UIDEDialoguePatch.cs
@@ -450,9 +450,12 @@ namespace GalacticScale
 
             if (cand2 > __instance.maxOrbitRadius)
             {
-                orbitRadius = __instance.minOrbitRadius;
+                // cand1 already passed the minOrbitRadius check above, so it is valid in [min, max].
+                // Use it rather than bailing out with minOrbitRadius + false, which would discard
+                // a perfectly good outward candidate and leave the OK button dead.
+                orbitRadius = cand1;
                 orbitAngularSpeed = ComputeAngularSpeed(__instance.gravity, orbitRadius);
-                __result = false;
+                __result = true;
                 return false;
             }
 

--- a/Scripts/Patches/DysonSphere/UIDEDialoguePatch.cs
+++ b/Scripts/Patches/DysonSphere/UIDEDialoguePatch.cs
@@ -298,32 +298,27 @@ namespace GalacticScale
             if (orbitRadius < __instance.minOrbitRadius) orbitRadius = __instance.minOrbitRadius;
             if (orbitRadius > __instance.maxOrbitRadius) orbitRadius = __instance.maxOrbitRadius;
 
-            if (__instance.starData?.planets != null)
-            {
-                for (int i = 0; i < __instance.starData.planets.Length; i++)
-                {
-                    var p = __instance.starData.planets[i];
-                    if (p != null && p.orbitRadius > 0f)
-                    {
-                        float pOrbitAU = p.orbitAround != 0 && p.orbitAroundPlanet != null ? p.orbitAroundPlanet.orbitRadius : p.orbitRadius;
-                        float pOrbit = (float)((double)pOrbitAU * 40000.0);
-                        if (Mathf.Abs(pOrbit - orbitRadius) < 2199.95f)
-                        {
-                            if (orbitRadius < pOrbit)
-                            {
-                                orbitRadius = Mathf.Floor(pOrbit - 2200f);
-                            }
-                            else
-                            {
-                                orbitRadius = Mathf.Ceil(pOrbit + 2200f);
-                            }
-                        }
-                    }
-                }
-            }
+            float requestedRadius = orbitRadius;
 
-            if (orbitRadius < __instance.minOrbitRadius) orbitRadius = __instance.minOrbitRadius;
-            if (orbitRadius > __instance.maxOrbitRadius) orbitRadius = __instance.maxOrbitRadius;
+            float cand1 = PushPlanetsCeil(__instance, requestedRadius);
+            if (cand1 > __instance.maxOrbitRadius)
+                cand1 = __instance.maxOrbitRadius;
+            cand1 = PushPlanetsFloor(__instance, cand1);
+
+            float cand2 = PushPlanetsFloor(__instance, requestedRadius);
+            if (cand2 < __instance.minOrbitRadius)
+                cand2 = __instance.minOrbitRadius;
+            cand2 = PushPlanetsCeil(__instance, cand2);
+
+            bool c1ok = cand1 >= __instance.minOrbitRadius && cand1 <= __instance.maxOrbitRadius;
+            bool c2ok = cand2 >= __instance.minOrbitRadius && cand2 <= __instance.maxOrbitRadius;
+            if (c1ok && c2ok)
+                orbitRadius = Mathf.Abs(cand1 - requestedRadius) < Mathf.Abs(cand2 - requestedRadius) ? cand1 : cand2;
+            else if (c1ok)
+                orbitRadius = cand1;
+            else if (c2ok)
+                orbitRadius = cand2;
+            // else: the whole [min,max] band sits inside a ring; leave the clamped request.
             return false;
         }
 

--- a/Scripts/Star Generation/StarDefaults.cs
+++ b/Scripts/Star Generation/StarDefaults.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using UnityEngine;
 
 namespace GalacticScale
@@ -226,40 +226,40 @@ namespace GalacticScale
             var s = star.Spectr;
 
             random = new GS2.Random(star.Seed);
-            GS2.Warn($"Testing Random 0.1-0.9f {random.NextFloat(0.1f, 0.9f)}");
+            GS2.Log($"DysonRadius: testing rand seed for {star.Name}: {random.NextFloat(0.1f, 0.9f)}");
             switch (t)
             {
-                case EStarType.BlackHole: GS2.Warn("Class BH");return random.NextFloat(0.69f, 0.76f);
-                case EStarType.NeutronStar: GS2.Warn("Class NS");return random.NextFloat(0.85f, 1.03f);
-                case EStarType.WhiteDwarf: GS2.Warn("Class WD");return random.NextFloat(0.24f, 0.55f);
+                case EStarType.BlackHole: GS2.Log("DysonRadius: Class BH"); return random.NextFloat(0.69f, 0.76f);
+                case EStarType.NeutronStar: GS2.Log("DysonRadius: Class NS"); return random.NextFloat(0.85f, 1.03f);
+                case EStarType.WhiteDwarf: GS2.Log("DysonRadius: Class WD"); return random.NextFloat(0.24f, 0.55f);
                 case EStarType.GiantStar:
                     switch (s)
                     {
-                        case ESpectrType.A: 
+                        case ESpectrType.A:
                         case ESpectrType.F:
                         case ESpectrType.G:
-                        case ESpectrType.K: GS2.Warn("Giant Class A-K"); return random.NextFloat(0.79f, 0.8f);
-                        case ESpectrType.B:GS2.Warn("Giant Class O");return random.NextFloat(2f, 3f);
-                        case ESpectrType.O: GS2.Warn("Giant Class O");return random.NextFloat(3f, 5f);
-                        case ESpectrType.M: GS2.Warn("Giant Class M");return random.NextFloat(0.75f, 1f);
+                        case ESpectrType.K: GS2.Log("DysonRadius: Giant Class A-K"); return random.NextFloat(0.79f, 0.8f);
+                        case ESpectrType.B: GS2.Log("DysonRadius: Giant Class B"); return random.NextFloat(2f, 3f);
+                        case ESpectrType.O: GS2.Log("DysonRadius: Giant Class O"); return random.NextFloat(3f, 5f);
+                        case ESpectrType.M: GS2.Log("DysonRadius: Giant Class M"); return random.NextFloat(0.75f, 1f);
                     }
-                    
+
                     break;
                 case EStarType.MainSeqStar:
                     switch (s)
                     {
-                        case ESpectrType.A: GS2.Warn("Class A (0.44-0.6)");return random.NextFloat(0.44f, 0.60f);
-                        case ESpectrType.B: GS2.Warn("Class B (0.59-0.8");return random.NextFloat(0.59f, 0.8f);
-                        case ESpectrType.F: GS2.Warn("Class F (0.325-0.545");return random.NextFloat(0.325f, 0.545f);
-                        case ESpectrType.G: GS2.Warn("Class G (0.26-0.33");return random.NextFloat(0.260f, 0.330f);
-                        case ESpectrType.K: GS2.Warn("Class K (0.239-0.264)");return random.NextFloat(0.239f, 0.264f);
-                        case ESpectrType.M: GS2.Warn("Class M (0.229-0.239)");return random.NextFloat(0.229f, 0.239f);
-                        case ESpectrType.O: GS2.Warn("Class O (0.8-0.93)");return random.NextFloat(0.8f, 0.93f);
+                        case ESpectrType.A: GS2.Log("DysonRadius: Class A (0.44-0.6)"); return random.NextFloat(0.44f, 0.60f);
+                        case ESpectrType.B: GS2.Log("DysonRadius: Class B (0.59-0.8)"); return random.NextFloat(0.59f, 0.8f);
+                        case ESpectrType.F: GS2.Log("DysonRadius: Class F (0.325-0.545)"); return random.NextFloat(0.325f, 0.545f);
+                        case ESpectrType.G: GS2.Log("DysonRadius: Class G (0.26-0.33)"); return random.NextFloat(0.260f, 0.330f);
+                        case ESpectrType.K: GS2.Log("DysonRadius: Class K (0.239-0.264)"); return random.NextFloat(0.239f, 0.264f);
+                        case ESpectrType.M: GS2.Log("DysonRadius: Class M (0.229-0.239)"); return random.NextFloat(0.229f, 0.239f);
+                        case ESpectrType.O: GS2.Log("DysonRadius: Class O (0.8-0.93)"); return random.NextFloat(0.8f, 0.93f);
                     }
 
                     break;
             }
-            GS2.Warn("Class Not Found!");
+            GS2.Warn($"DysonRadius: unhandled star type={t} spectr={s} for {star.Name} — returning 0");
             return 0f;
         }
 

--- a/setup_devenv.ps1
+++ b/setup_devenv.ps1
@@ -18,6 +18,21 @@ function Find-DSPPlugins {
     return $null
 }
 
+function Find-DSPGameDir {
+    $commonPaths = @(
+        "$env:ProgramFiles\Steam\steamapps\common\Dyson Sphere Program",
+        "${env:ProgramFiles(x86)}\Steam\steamapps\common\Dyson Sphere Program",
+        "D:\SteamLibrary\steamapps\common\Dyson Sphere Program",
+        "E:\SteamLibrary\steamapps\common\Dyson Sphere Program"
+    )
+    foreach ($path in $commonPaths) {
+        if (Test-Path "$path\DSPGAME.exe") {
+            return $path
+        }
+    }
+    return $null
+}
+
 function Select-PluginsFolder {
     $dialog = New-Object System.Windows.Forms.FolderBrowserDialog
     $dialog.Description = "Select your DSP BepInEx plugins folder"
@@ -25,6 +40,22 @@ function Select-PluginsFolder {
     
     # Try to start in a sensible location
     $initialPath = Find-DSPPlugins
+    if ($initialPath) {
+        $dialog.SelectedPath = $initialPath
+    }
+    
+    if ($dialog.ShowDialog() -eq 'OK') {
+        return $dialog.SelectedPath
+    }
+    return $null
+}
+
+function Select-GameFolder {
+    $dialog = New-Object System.Windows.Forms.FolderBrowserDialog
+    $dialog.Description = "Select your Dyson Sphere Program game folder (contains DSPGAME.exe)"
+    $dialog.ShowNewFolderButton = $false
+    
+    $initialPath = Find-DSPGameDir
     if ($initialPath) {
         $dialog.SelectedPath = $initialPath
     }
@@ -52,6 +83,7 @@ function Test-PluginsDirectory {
 Write-Host "GalacticScale 3 Development Environment Setup" -ForegroundColor Cyan
 Write-Host "----------------------------------------" -ForegroundColor Cyan
 
+# --- Plugins directory ---
 $pluginsPath = Find-DSPPlugins
 if (-not $pluginsPath) {
     Write-Host "Could not automatically find DSP plugins directory."
@@ -73,12 +105,35 @@ if (-not (Test-PluginsDirectory $pluginsPath)) {
     }
 }
 
+# --- Game directory ---
+$gameDir = Find-DSPGameDir
+if (-not $gameDir) {
+    Write-Host "Could not automatically find DSP game directory."
+    Write-Host "Please select the folder containing DSPGAME.exe..."
+    $gameDir = Select-GameFolder
+}
+
+if (-not $gameDir) {
+    Write-Host "No game directory selected. Setup cancelled." -ForegroundColor Red
+    exit 1
+}
+
+if (-not (Test-Path "$gameDir\DSPGAME.exe")) {
+    Write-Host "Warning: Selected folder does not appear to contain DSPGAME.exe." -ForegroundColor Yellow
+    $confirm = Read-Host "Continue anyway? (y/N)"
+    if ($confirm -ne "y") {
+        Write-Host "Setup cancelled." -ForegroundColor Red
+        exit 1
+    }
+}
+
 # Create DevEnv.targets with the correct format
 $devEnvContent = @"
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <PluginDir>$pluginsPath</PluginDir>
+    <GameDir>$gameDir</GameDir>
   </PropertyGroup>
 </Project>
 "@
@@ -86,5 +141,7 @@ $devEnvContent = @"
 $devEnvContent | Out-File "DevEnv.targets" -Encoding UTF8
 
 Write-Host "`nSetup complete!" -ForegroundColor Green
-Write-Host "Created DevEnv.targets with plugins path: $pluginsPath"
-Write-Host "You can now build the project in Visual Studio." 
+Write-Host "Created DevEnv.targets with:"
+Write-Host "  PluginDir: $pluginsPath"
+Write-Host "  GameDir:   $gameDir"
+Write-Host "You can now build the project in Visual Studio."


### PR DESCRIPTION
## Summary of Changes

This PR reworks the **Dyson Sphere & Solar Swarm geometric scaling, editor camera synchronization, collision validation, and projectile/rocket flight physics** in Galactic Scale.

---

### 1. Problems Identified in Previous Implementation

1. **Flawed Luminosity-Coupled Geometric Sizing (`radius * _luminosity * 0.25f`)**:
   - In vanilla DSP, luminosity strictly scales energy output ( $P = P_{base} \times L^{0.33}$ ), while geometry is governed by stellar physical size and orbital layout.
   - GS2 multiplied luminosity directly into the physical radius formula in `InitDysonRadius()`. This caused extreme polarization:
     - **Class O / Blue Giants** ( $L \approx 12\text{–}50$ ): Sphere radii exploded to **4,000,000m – 8,000,000m** (100–200 AU), shrinking the central star to an unviewable sub-pixel dot.
     - **Neutron Stars / Black Holes / White Dwarfs** ( $L \approx 0.005\text{–}0.35$ ): Sphere radii collapsed to the minimum clamp floor of **16,000m**, smaller than ordinary stars despite having large physics envelopes.
2. **Extreme Travel Times for Sails & Rockets in Large Systems**:
   - In expanded systems (50–150 AU), fixed sail bullet speeds (5,000 m/s) and unscaled carrier rockets resulted in flight times exceeding 10–15 minutes, heavily stalling megastructure construction.
3. **Unregistered Dyson Patches in `Bootstrap.cs`**:
   - `PatchOnDysonSphere` was left commented out in `ApplyHarmonyPatches()`, along with the three new patch classes — none of the Dyson logic was executing in-game.

---

### 2. Solutions & Key Improvements

1. **Pure Geometric Sizing Formula**:

$$R_{min} = R_{physics} + 0.1 \text{ AU} \quad (R_{physics} = \texttt{starData.radius} \times 1200 \text{ m})$$

$$R_{max} = \text{Farthest Planet Orbit} + 1.0 \text{ AU} \quad \text{(fallback: } R_{min} + 1.0 \text{ AU if no planets)}$$

$$R_{def} = R_{min} + (R_{max} - R_{min}) \times 0.25$$

   Completely decoupled from `_luminosity`.

2. **Dynamic Orbit Refresh**:
   - Added `DysonSphereUtils.RefreshDysonOrbitBounds()` hooked into `UIDysonEditor.OnViewStarChange`, `UIDEAddSwarmDialogue`, and `UIDEAddLayerDialogue`. Solves the universe generation lifecycle (where `DysonSphere.Init` runs before planet arrays are populated) by recalculating bounds from live system planets on UI open.

3. **Multi-Planet Collision & Boundary Harmony Hooks**:
   - Patched `CheckSwarmRadius`, `CheckLayerRadius`, `QuerySwarmRadius`, and `QueryLayerRadius` to check against all planets in the system rather than solely `planet[0]`.
   - `QueryLayerRadius` now uses a full bidirectional two-candidate search (outward-first and inward-first), selecting whichever candidate lands closest to the originally requested radius.

4. **Adaptive Camera Frustum & Auto-Zoom**:
   - Synchronized `cameraController.maxDist` and `screenCamera.farClipPlane` with the star's actual `maxOrbitRadius`.
   - Auto-zoom tracking in `UIDEAddSwarmDialogue` and `UIDEAddLayerDialogue` keeps the preview sphere framed when dragging the radius slider.

5. **Dynamic Flight Speed Scaling**:
   - **Solar Sails (Ejector Bullet)**:

$$v_{bullet} = 5000 \text{ m/s} \times \max\!\left(1.0,\ \sqrt{\frac{d_{target}}{40000 \text{ m}}}\right)$$

   - **Carrier Rockets (Silo)**:

$$s = \max\!\left(1.0,\ \frac{R_{max}}{40000 \text{ m}}\right)$$

$$v_{max} = 2800 \text{ m/s} \times s^{0.6} \qquad a = 7.5 \text{ m/s}^2 \times s^{0.6}$$

   Both formulas significantly reduce transit times compared to fixed-speed vanilla behaviour in large GS2 systems.

6. **Enabled & Registered in `Bootstrap.cs`**:
   - Registered `PatchOnDysonSphere`, `PatchOnDysonSwarm`, `PatchOnDysonSphereRocket`, and `PatchOnUIDEDialogues` in `ApplyHarmonyPatches()`.

---

### 3. Comparison: Vanilla vs GS2 (Previous) vs This PR

| Star Type | Physical Radius | Vanilla DSP Orbit Range (Min → Max) | GS2 Previous (with L) | This PR (R_min → R_max) |
| :--- | :--- | :--- | :--- | :--- |
| **Type G (Solar)** | ~1,000m – 1,500m | 4,000m → ~30,000m – 60,000m | ~100,000m – 200,000m | **~5,200m → Farthest Planet + 1 AU** |
| **Type O (Hyper-luminous)** | ~3,600m – 6,700m | ~5,400m → ~80,000m – 160,000m | **~1,000,000m – 4,000,000m** *(Exploded)* | **~8,800m → Farthest Planet + 1 AU** |
| **Giant Stars** | ~14,400m – 37,200m | ~22,000m → ~200,000m – 460,000m | **~2,000,000m – 8,000,000m** | **~25,000m – ~41,200m → Farthest Planet + 1 AU** |
| **Neutron Star** | ~440m – 620m | 4,000m → ~30,000m – 60,000m | **16,000m – 32,000m** *(Collapsed)* | **~4,500m → Farthest Planet + 1 AU** |
| **Black Hole** | ~4,140m – 5,520m | ~6,200m → ~30,000m – 60,000m | **16,000m – 32,000m** *(Collapsed)* | **~8,800m → Farthest Planet + 1 AU** |

---

### 4. Compatibility & Safety
- **Save Game Safe**: No changes to binary serialization formats (Export/Import). Existing layers and structures load with exact coordinate integrity. Legacy layers built under the old formula are accommodated — `RefreshDysonOrbitBounds` floors `maxOrbitRadius` at the highest existing layer so old saves remain viewable and editable.
- **Rollback Safe**: Mod can be safely added or removed without breaking saves.
