### PR TITLE
Fix planets of overlapping systems never becoming local (fixes #294)

### DIFF
--- a/Scripts/Utils/HandleLocalStarPlanets.cs
+++ b/Scripts/Utils/HandleLocalStarPlanets.cs
@@ -307,7 +307,11 @@ namespace GalacticScale
         /// </summary>
         private static double ApproachDistance(PlanetData planet)
         {
-            var wide = planet.realRadius * 4.0 + 20000.0;
+            // 80000 (2 AU) floor: field-tested — a 20000 floor made the handoff (and with it
+            // the planet popping into existence) happen at ~0.5 AU, which reads as still-broken
+            // to a player flying at an invisible planet. 2 AU triggers before the approach
+            // feels wrong.
+            var wide = planet.realRadius * 4.0 + 80000.0;
             var transition = TransitionDistance(planet);
             return wide > transition ? wide : transition;
         }

--- a/Scripts/Utils/HandleLocalStarPlanets.cs
+++ b/Scripts/Utils/HandleLocalStarPlanets.cs
@@ -193,21 +193,39 @@ namespace GalacticScale
         {
             var stars = GameMain.galaxy?.stars;
             if (stars == null) return null;
+
+            // Hysteresis: while still in approach of a body we already own, never yield.
+            if (closestStar?.planets != null)
+                for (var j = 0; j < closestStar.planetCount; j++)
+                {
+                    var planet = closestStar.planets[j];
+                    if (planet != null && DistanceTo(planet) < ApproachDistance(planet))
+                        return null;
+                }
+
+            PlanetData best = null;
+            var bestDist = double.MaxValue;
             for (var i = 0; i < GameMain.galaxy.starCount; i++)
             {
                 var star = stars[i];
                 if (star == null || star == closestStar || star.planetCount == 0) continue;
-                if (GetGSStar(star).Decorative) continue;
+                var gs = GetGSStar(star);
+                if (gs == null || gs.Decorative) continue;
                 if (DistanceTo(star) >= TransitionDistance(star)) continue;
                 for (var j = 0; j < star.planetCount; j++)
                 {
                     var planet = star.planets[j];
                     if (planet == null) continue;
-                    if (DistanceTo(planet) < ApproachDistance(planet)) return planet;
+                    var d = DistanceTo(planet);
+                    if (d < ApproachDistance(planet) && d < bestDist)
+                    {
+                        best = planet;
+                        bestDist = d;
+                    }
                 }
             }
 
-            return null;
+            return best;
         }
 
         private static void EnsurePlanetStillLocal()
@@ -243,12 +261,14 @@ namespace GalacticScale
             StarData byPlanet = null;
             StarData byCenter = null;
             var bestCenterDist = double.MaxValue;
+            var bestPlanetDist = double.MaxValue;
             for (var i = 0; i < GameMain.galaxy.starCount; i++)
             {
                 var star = GameMain.galaxy.stars[i];
                 if (star.planetCount == 0) continue;
 
-                if (GetGSStar(star).Decorative) continue;
+                var gs = GetGSStar(star);
+                if (gs == null || gs.Decorative) continue;
 
                 var dist = DistanceTo(star);
                 if (dist >= TransitionDistance(star)) continue;
@@ -259,17 +279,17 @@ namespace GalacticScale
                     bestCenterDist = dist;
                 }
 
-                if (byPlanet == null)
-                    for (var j = 0; j < star.planetCount; j++)
+                for (var j = 0; j < star.planetCount; j++)
+                {
+                    var planet = star.planets[j];
+                    if (planet == null) continue;
+                    var pd = DistanceTo(planet);
+                    if (pd < ApproachDistance(planet) && pd < bestPlanetDist)
                     {
-                        var planet = star.planets[j];
-                        if (planet == null) continue;
-                        if (DistanceTo(planet) < ApproachDistance(planet))
-                        {
-                            byPlanet = star;
-                            break;
-                        }
+                        byPlanet = star;
+                        bestPlanetDist = pd;
                     }
+                }
             }
 
             closestStar = byPlanet ?? byCenter;

--- a/Scripts/Utils/HandleLocalStarPlanets.cs
+++ b/Scripts/Utils/HandleLocalStarPlanets.cs
@@ -161,10 +161,53 @@ namespace GalacticScale
         private static void EnsureStarStillLocal()
         {
             if (closestStar.loaded) LogStatus($"Ensure {closestStar.name} still local...");
-            if (!(DistanceTo(closestStar) > TransitionDistance(closestStar))) return;
-            Log($"Leaving star {closestStar.name} as its too far away {DistanceTo(closestStar) / 40000}AU < {TransitionDistance(closestStar) / 40000}AU");
-            GameMain.data.LeaveStar();
-            closestStar = null;
+            if (DistanceTo(closestStar) > TransitionDistance(closestStar))
+            {
+                Log($"Leaving star {closestStar.name} as its too far away {DistanceTo(closestStar) / 40000}AU < {TransitionDistance(closestStar) / 40000}AU");
+                GameMain.data.LeaveStar();
+                closestStar = null;
+                return;
+            }
+
+            // Overlapping systems (#294): GS2 orbits can be wide enough that a planet of a
+            // NEIGHBORING star is right here while the current star's own bodies are dozens of
+            // AU away. The current star's transition sphere still contains the player, so the
+            // exit check above never fires and the neighbor's planet can never load (invisible,
+            // no collider, factory never mounts). Yield only on decisive contact: the player is
+            // inside the transition sphere of a planet belonging to another eligible star.
+            var foreign = TouchedPlanetOfOtherStar();
+            if (foreign != null)
+            {
+                Log($"Leaving star {closestStar.name}: in contact with {foreign.name} of {foreign.star.name} (overlapping systems)");
+                GameMain.data.LeaveStar();
+                closestStar = null;
+            }
+        }
+
+        /// <summary>
+        ///     Returns a planet of a different, locality-eligible star whose transition sphere
+        ///     contains the player, or null. Only stars whose own system sphere contains the
+        ///     player are examined, so in non-overlapping space this is a single distance check.
+        /// </summary>
+        private static PlanetData TouchedPlanetOfOtherStar()
+        {
+            var stars = GameMain.galaxy?.stars;
+            if (stars == null) return null;
+            for (var i = 0; i < GameMain.galaxy.starCount; i++)
+            {
+                var star = stars[i];
+                if (star == null || star == closestStar || star.planetCount == 0) continue;
+                if (GetGSStar(star).Decorative) continue;
+                if (DistanceTo(star) >= TransitionDistance(star)) continue;
+                for (var j = 0; j < star.planetCount; j++)
+                {
+                    var planet = star.planets[j];
+                    if (planet == null) continue;
+                    if (DistanceTo(planet) < ApproachDistance(planet)) return planet;
+                }
+            }
+
+            return null;
         }
 
         private static void EnsurePlanetStillLocal()
@@ -191,23 +234,62 @@ namespace GalacticScale
 
         private static void SearchStar()
         {
-            for (var i = 0; closestStar == null && i < GameMain.galaxy.starCount; i++)
+            // Overlapping systems (#294): several stars' transition spheres can contain the
+            // player at once. The old first-index-wins pick could hand locality to a star whose
+            // bodies are dozens of AU away while the player is parked ON a planet of another.
+            // Pick, among containing stars: first any star with a planet whose transition sphere
+            // contains the player (we are AT one of its bodies), else the star with the nearest
+            // center. With a single candidate this is exactly the old behavior.
+            StarData byPlanet = null;
+            StarData byCenter = null;
+            var bestCenterDist = double.MaxValue;
+            for (var i = 0; i < GameMain.galaxy.starCount; i++)
             {
                 var star = GameMain.galaxy.stars[i];
                 if (star.planetCount == 0) continue;
 
                 if (GetGSStar(star).Decorative) continue;
 
-                if (DistanceTo(star) < TransitionDistance(star))
+                var dist = DistanceTo(star);
+                if (dist >= TransitionDistance(star)) continue;
+
+                if (dist < bestCenterDist)
                 {
-                    Log($"Found Star {star.name}");
-                    closestStar = star;
+                    byCenter = star;
+                    bestCenterDist = dist;
                 }
 
-                if (!GameMain.isRunning || closestStar == null || closestStar.loaded) continue;
-                closestStar.Load();
-                return;
+                if (byPlanet == null)
+                    for (var j = 0; j < star.planetCount; j++)
+                    {
+                        var planet = star.planets[j];
+                        if (planet == null) continue;
+                        if (DistanceTo(planet) < ApproachDistance(planet))
+                        {
+                            byPlanet = star;
+                            break;
+                        }
+                    }
             }
+
+            closestStar = byPlanet ?? byCenter;
+            if (closestStar == null) return;
+            Log($"Found Star {closestStar.name}" + (byPlanet != null ? " (owns the planet at hand)" : ""));
+
+            if (GameMain.isRunning && !closestStar.loaded) closestStar.Load();
+        }
+
+        /// <summary>
+        ///     Wide sphere used to decide that the player is meaningfully AT a foreign star's
+        ///     planet. Much larger than the landing transition sphere so the ownership switch
+        ///     (and with it rendering/collision of the planet) happens on approach instead of
+        ///     after blindly hitting an invisible surface.
+        /// </summary>
+        private static double ApproachDistance(PlanetData planet)
+        {
+            var wide = planet.realRadius * 4.0 + 20000.0;
+            var transition = TransitionDistance(planet);
+            return wide > transition ? wide : transition;
         }
 
         public static double DistanceTo(PlanetData planet)


### PR DESCRIPTION
Fixes #294 — planets of overlapping systems could never load: invisible, no collider, no warp-brake, factory never mounts, while logistics vessels kept docking at the position. Deterministic across reload and restart.

## Mechanism

GS2 orbits reach 60–100+ AU, so neighboring stars' system spheres (`SystemRadius + 2 AU`) can interpenetrate — breaking the engine assumption that a planet is always nearest its own star. GS2's locality replacement (`HandleLocalStarPlanets`, which supersedes vanilla `DetermineLocalPlanet`) compounded this two ways:

1. `SearchStar` assigned locality to the **first star by galaxy index** whose sphere contains the player (the loop stopped at the first hit) — not the nearest, not the owner of the planet you're at.
2. `EnsureStarStillLocal` kept that star until the player left its **entire system sphere** — so standing on a planet of the *other* overlapping star could never hand locality to its owner, and the planet never loaded.

The historical "landed on an invisible planet, saw my base, fell through the surface and rubber-banded" reports are the marginal form of the same defect (entry-order/near-equidistant flapping).

## Fix (all within `HandleLocalStarPlanets`, no new patch surface)

- **Pick rule** — `SearchStar` now collects every star whose sphere contains the player and prefers the one owning the **nearest planet in approach** (approach sphere = `4×radius + 2 AU floor`), falling back to nearest center. Single-candidate behavior is unchanged, i.e. all of non-overlapping space behaves exactly as before.
- **Yield rule** — `EnsureStarStillLocal` additionally yields the current star when the player enters the approach sphere of another eligible star's planet, so the owner takes over, loads, renders, and mounts collision. It never yields while the player is still in approach of a body of the current star.
- **Hysteresis** — switching in requires planet contact; switching out requires leaving the whole system sphere. No flapping in open space, and after takeoff the new star stays local until genuine departure.

## Verification

- Adversarial review walked the full state machine: takeoff/return flapping, mid-warp switches (vanilla-equivalent), `LeaveStar` unload semantics for in-flight vessels, the star-loading branch, and per-tick cost (O(starCount) distance checks + O(1) dictionary lookups). The first-by-index candidate ordering it flagged is fixed (nearest-contact wins in both pickers).
- **Field-tested on the live repro save**: planet materialized — rendered, solid, landable, factory mounted — at exactly the coded approach boundary, first at the initial 0.5 AU floor, then re-tested at the tuned 2 AU floor. Fly-away/return confirmed stable ownership with no flapping.

@ZordDevzz — you were in the neighboring code for the Dyson rescale (camera/bounds), so if you feel like giving this a once-over, very welcome; no obligation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
